### PR TITLE
feat: 질문 목록 조회 api 구현

### DIFF
--- a/src/main/java/com/hanshin/supernova/community/domain/CommunityMember.java
+++ b/src/main/java/com/hanshin/supernova/community/domain/CommunityMember.java
@@ -26,6 +26,8 @@ public class CommunityMember extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String communityName;
+
     @Enumerated
     private Autority autority;
 

--- a/src/main/java/com/hanshin/supernova/community/infrastructure/CommunityMemberRepository.java
+++ b/src/main/java/com/hanshin/supernova/community/infrastructure/CommunityMemberRepository.java
@@ -1,8 +1,10 @@
 package com.hanshin.supernova.community.infrastructure;
 
 import com.hanshin.supernova.community.domain.CommunityMember;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommunityMemberRepository extends JpaRepository<CommunityMember, Long> {
 
+    List<CommunityMember> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/hanshin/supernova/exception/dto/ErrorType.java
+++ b/src/main/java/com/hanshin/supernova/exception/dto/ErrorType.java
@@ -23,7 +23,6 @@ public enum ErrorType {
     NON_IDENTICAL_USER_ERROR(HttpStatus.FORBIDDEN, "작성자와 접근자가 일치하지 않습니다."),
 
     // 질문 예외
-    NEITHER_BLANK_ERROR(HttpStatus.BAD_REQUEST, "제목과 내용은 빈 문자열일 수 없습니다."),
     QUESTION_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "id에 해당하는 질문이 존재하지 않습니다."),
 
     // 해시태그 예외

--- a/src/main/java/com/hanshin/supernova/question/application/QuestionListService.java
+++ b/src/main/java/com/hanshin/supernova/question/application/QuestionListService.java
@@ -1,0 +1,109 @@
+package com.hanshin.supernova.question.application;
+
+import com.hanshin.supernova.community.infrastructure.CommunityRepository;
+import com.hanshin.supernova.exception.community.CommunityInvalidException;
+import com.hanshin.supernova.exception.dto.ErrorType;
+import com.hanshin.supernova.question.domain.Question;
+import com.hanshin.supernova.question.dto.response.QuestionInfoResponse;
+import com.hanshin.supernova.question.infrastructure.QuestionRepository;
+import java.awt.print.Pageable;
+import java.util.LinkedList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionListService {
+
+    private final QuestionRepository questionRepository;
+    private final CommunityRepository communityRepository;
+
+    /**
+     * 답변이 채택되지 않은 질문 목록 - 최신 순
+     */
+    public List<QuestionInfoResponse> getUnAnsweredQuestionsByDesc(Long cId) {
+        isCommunityExistsById(cId);
+
+        List<Question> findUnAnsweredQuestions = questionRepository.findAllByCommIdAndIsResolvedOrderByCreatedAtDesc(
+                cId, false);
+
+        return getQuestionInfoResponses(
+                findUnAnsweredQuestions);
+    }
+
+    /**
+     * 답변이 채택되지 않은 질문 N개 목록 - 최신 순
+     */
+    public List<QuestionInfoResponse> getUnAnswered4QuestionsByDesc(Long cId, int n) {
+        isCommunityExistsById(cId);
+
+        List<Question> findUnAnsweredQuestions = questionRepository.findTopNByIsResolvedOrderByCreatedAtDesc(
+                false,
+                (Pageable) PageRequest.of(0, n));
+
+        return getQuestionInfoResponses(
+                findUnAnsweredQuestions);
+    }
+
+    /**
+     * 답변이 채택되지 않은 질문 목록 - 오래된 순
+     */
+    public List<QuestionInfoResponse> getUnAnsweredQuestionsByAsc(Long cId) {
+        isCommunityExistsById(cId);
+
+        List<Question> findUnAnsweredQuestions = questionRepository.findAllByCommIdAndIsResolvedOrderByCreatedAtAsc(
+                cId, false);
+
+        return getQuestionInfoResponses(
+                findUnAnsweredQuestions);
+    }
+
+    /**
+     * 전체 질문 목록 - 최신 순
+     */
+    public List<QuestionInfoResponse> getAllQuestionsByDesc(Long cId) {
+        isCommunityExistsById(cId);
+
+        List<Question> findAllQuestions = questionRepository.findAllByCommIdOrderByCreatedAtDesc(
+                cId);
+
+        return getQuestionInfoResponses(
+                findAllQuestions);
+    }
+
+    /**
+     * 커뮤니티별 전체 질문 - 오래된 순
+     */
+    public List<QuestionInfoResponse> getAllQuestionsByAsc(Long cId) {
+        isCommunityExistsById(cId);
+
+        List<Question> findAllQuestions = questionRepository.findAllByCommIdOrderByCreatedAtAsc(
+                cId);
+
+        return getQuestionInfoResponses(
+                findAllQuestions);
+    }
+
+
+    private void isCommunityExistsById(Long commId) {
+        if (!communityRepository.existsById(commId)) {
+            throw new CommunityInvalidException(ErrorType.COMMUNITY_NOT_FOUND_ERROR);
+        }
+    }
+
+    private static List<QuestionInfoResponse> getQuestionInfoResponses(
+            List<Question> findUnAnsweredQuestions) {
+        List<QuestionInfoResponse> questionInfoResponses = new LinkedList<>();
+        findUnAnsweredQuestions.forEach(question -> {
+            questionInfoResponses.add(QuestionInfoResponse.toResponse(
+                    question.getId(),
+                    question.getTitle(),
+                    question.getContent()
+            ));
+        });
+        return questionInfoResponses;
+    }
+
+}

--- a/src/main/java/com/hanshin/supernova/question/application/QuestionService.java
+++ b/src/main/java/com/hanshin/supernova/question/application/QuestionService.java
@@ -1,19 +1,23 @@
 package com.hanshin.supernova.question.application;
 
 import com.hanshin.supernova.common.dto.SuccessResponse;
+import com.hanshin.supernova.community.domain.CommunityMember;
+import com.hanshin.supernova.community.infrastructure.CommunityMemberRepository;
+import com.hanshin.supernova.community.infrastructure.CommunityRepository;
 import com.hanshin.supernova.exception.auth.AuthInvalidException;
+import com.hanshin.supernova.exception.community.CommunityInvalidException;
 import com.hanshin.supernova.exception.dto.ErrorType;
 import com.hanshin.supernova.exception.question.QuestionInvalidException;
 import com.hanshin.supernova.question.domain.Question;
 import com.hanshin.supernova.question.domain.QuestionView;
 import com.hanshin.supernova.question.dto.request.QuestionRequest;
-import com.hanshin.supernova.question.dto.response.QuestionInfoResponse;
+import com.hanshin.supernova.question.dto.response.CommunityInfoResponse;
 import com.hanshin.supernova.question.dto.response.QuestionResponse;
 import com.hanshin.supernova.question.dto.response.QuestionSaveResponse;
 import com.hanshin.supernova.question.infrastructure.QuestionRepository;
 import com.hanshin.supernova.question.infrastructure.QuestionViewRepository;
 import java.time.LocalDateTime;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,30 +29,25 @@ public class QuestionService {
 
     private final QuestionRepository questionRepository;
     private final QuestionViewRepository questionViewRepository;
+    private final CommunityRepository communityRepository;
+    private final CommunityMemberRepository communityMemberRepository;
 
     /**
      * 질문 등록
      */
     @Transactional
     public QuestionSaveResponse createQuestion(QuestionRequest request) {
+        isCommunityExistsById(request.getCommId());
 
-        isTitleAndContentNeitherBlank(request);
-
-        // TODO user 정보 받아오기
-
-        // TODO commId 유효성 검사
-
+        Long user_id = 1L;  // TODO user 정보 받아오기
         Question question = Question.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
-                .questionerId(1L)   // TODO user id
+                .questionerId(user_id)
                 .commId(request.getCommId())
                 .build();
 
         Question savedQuestion = questionRepository.save(question);
-
-        // TODO community save logic
-//        communityService.registerQuestion()
 
         // TODO ContentWord save logic
 
@@ -58,7 +57,7 @@ public class QuestionService {
     /**
      * 질문 조회
      */
-//    @Transactional(readOnly = true)
+    @Transactional
     public QuestionResponse getQuestion(Long qId) {
 
         // 조회를 시도하는 회원의 중복 체크 및 조회수 증가
@@ -95,25 +94,19 @@ public class QuestionService {
      */
     @Transactional
     public QuestionSaveResponse editQuestion(Long qId, QuestionRequest request) {
+        isCommunityExistsById(request.getCommId());
 
         Question findQuestion = getQuestionById(qId);
 
-        // TODO user 정보 받아오기
-        Long user_id = 1L;
+        Long user_id = 1L;  // TODO user 정보 받아오기
         validateSameUserById(findQuestion, user_id);
 
-        // TODO commId 유효성 검사
-
-        isTitleAndContentNeitherBlank(request);
         findQuestion.updateQuestion(request.getTitle(), request.getContent(), request.getCommId());
-
-        // TODO community update logic
 
         // TODO ContentWord update logic
 
         return QuestionSaveResponse.toResponse(findQuestion.getId());
     }
-
 
     /**
      * 질문 삭제
@@ -123,8 +116,7 @@ public class QuestionService {
 
         Question findQuestion = getQuestionById(qId);
 
-        // TODO user 정보 받아오기
-        Long user_id = 1L;
+        Long user_id = 1L;  // TODO user 정보 받아오기
         validateSameUserById(findQuestion, user_id);
 
         questionRepository.deleteById(qId);
@@ -133,39 +125,34 @@ public class QuestionService {
     }
 
     /**
-     * 질문 목록 제공
+     * 사용자가 등록된 커뮤니티 목록 제공
      */
-//    public List<QuestionInfoResponse> getUnAnsweredQuestions(Long cId) {
-//
-//        // TODO community 정보 받아오기
-//
-//        List<Question> findUnAnsweredQuestions = questionRepository.findAllByCommIdAndIsResolved(
-//                cId, false);
-//
-//        return getQuestionInfoResponses(
-//                findUnAnsweredQuestions);
-//    }
-//
-//    public List<QuestionInfoResponse> getAllQuestions(Long cId) {
-//
-//        // TODO community 정보 받아오기
-//
-//        List<Question> findAllQuestions = questionRepository.findAllByCommId(cId);
-//
-//        return getQuestionInfoResponses(
-//                findAllQuestions);
-//    }
+    @Transactional(readOnly = true)
+    public List<CommunityInfoResponse> getMyCommunities(Long qId) {
+        Long user_id = 1L;  // TODO user 정보 받아오기
+        List<CommunityInfoResponse> communityInfoResponses = new ArrayList<>();
 
+        List<CommunityMember> findCMembers = communityMemberRepository.findAllByUserId(user_id);
+        findCMembers.forEach(findMember -> {
+            communityInfoResponses.add(CommunityInfoResponse.toResponse(
+                    findMember.getCommunityId(),
+                    findMember.getCommunityName()
+            ));
+        });
+
+        return communityInfoResponses;
+    }
+
+
+    private void isCommunityExistsById(Long commId) {
+        if (!communityRepository.existsById(commId)) {
+            throw new CommunityInvalidException(ErrorType.COMMUNITY_NOT_FOUND_ERROR);
+        }
+    }
 
     private static void validateSameUserById(Question findQuestion, Long user_id) {
         if (!findQuestion.getQuestionerId().equals(user_id)) {
             throw new AuthInvalidException(ErrorType.NON_IDENTICAL_USER_ERROR);
-        }
-    }
-
-    private static void isTitleAndContentNeitherBlank(QuestionRequest request) {
-        if (request.getTitle().isBlank() || request.getContent().isBlank()) {
-            throw new QuestionInvalidException(ErrorType.NEITHER_BLANK_ERROR);
         }
     }
 
@@ -174,18 +161,5 @@ public class QuestionService {
                 () -> new QuestionInvalidException(ErrorType.QUESTION_NOT_FOUND_ERROR)
         );
     }
-
-//    private static List<QuestionInfoResponse> getQuestionInfoResponses(
-//            List<Question> findUnAnsweredQuestions) {
-//        List<QuestionInfoResponse> questionInfoResponses = new LinkedList<>();
-//        findUnAnsweredQuestions.forEach(question -> {
-//            questionInfoResponses.add(QuestionInfoResponse.toResponse(
-//                    question.getId(),
-//                    question.getTitle(),
-//                    question.getContent()
-//            ));
-//        });
-//        return questionInfoResponses;
-//    }
 
 }

--- a/src/main/java/com/hanshin/supernova/question/dto/response/CommunityInfoResponse.java
+++ b/src/main/java/com/hanshin/supernova/question/dto/response/CommunityInfoResponse.java
@@ -1,0 +1,18 @@
+package com.hanshin.supernova.question.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CommunityInfoResponse {
+
+    private Long cId;
+    private String cName;
+
+    public static CommunityInfoResponse toResponse(
+            Long communityId, String cName
+    ) {
+        return new CommunityInfoResponse(communityId, cName);
+    }
+}

--- a/src/main/java/com/hanshin/supernova/question/infrastructure/QuestionRepository.java
+++ b/src/main/java/com/hanshin/supernova/question/infrastructure/QuestionRepository.java
@@ -1,8 +1,10 @@
 package com.hanshin.supernova.question.infrastructure;
 
 import com.hanshin.supernova.question.domain.Question;
+import java.awt.print.Pageable;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,7 +12,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    List<Question> findAllByCommIdAndIsResolved(Long c_id, boolean isResolved);
+    List<Question> findAllByCommIdAndIsResolvedOrderByCreatedAtAsc(Long c_id, boolean isResolved);
 
-    List<Question> findAllByCommId(Long c_id);
+    List<Question> findAllByCommIdAndIsResolvedOrderByCreatedAtDesc(Long c_id, boolean isResolved);
+
+    List<Question> findAllByCommIdOrderByCreatedAtDesc(Long c_id);
+
+    List<Question> findAllByCommIdOrderByCreatedAtAsc(Long c_id);
+
+    List<Question> findTopNByIsResolvedOrderByCreatedAtDesc(boolean isResolved, Pageable pageable);
 }

--- a/src/main/java/com/hanshin/supernova/question/presentation/QuestionController.java
+++ b/src/main/java/com/hanshin/supernova/question/presentation/QuestionController.java
@@ -3,7 +3,9 @@ package com.hanshin.supernova.question.presentation;
 import com.hanshin.supernova.common.model.ResponseDto;
 import com.hanshin.supernova.question.application.QuestionService;
 import com.hanshin.supernova.question.dto.request.QuestionRequest;
+import com.hanshin.supernova.question.dto.response.CommunityInfoResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,27 +18,27 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(path = "/api")
+@RequestMapping(path = "/api/questions")
 @RequiredArgsConstructor
 public class QuestionController {
 
     private final QuestionService questionService;
 
-    @PostMapping(path = "/questions")
+    @PostMapping
     public ResponseEntity<?> createQuestion(
             @RequestBody @Valid QuestionRequest request) {
         var response = questionService.createQuestion(request);
         return ResponseDto.created(response);
     }
 
-    @GetMapping(path = "/questions/{q_id}")
+    @GetMapping(path = "/{q_id}")
     public ResponseEntity<?> readQuestion(
             @PathVariable("q_id") Long q_id) {
         var response = questionService.getQuestion(q_id);
         return ResponseDto.ok(response);
     }
 
-    @PutMapping(path = "/questions/{q_id}")
+    @PutMapping(path = "/{q_id}")
     public ResponseEntity<?> updateQuestion(
             @PathVariable("q_id") Long q_id,
             @RequestBody @Valid QuestionRequest request) {
@@ -44,7 +46,7 @@ public class QuestionController {
         return ResponseDto.ok(response);
     }
 
-    @DeleteMapping(path = "/questions/{q_id}")
+    @DeleteMapping(path = "/{q_id}")
     public ResponseEntity<?> deleteQuestion(
             @PathVariable("q_id") Long q_id
     ) {
@@ -52,21 +54,12 @@ public class QuestionController {
         return ResponseDto.ok(response);
     }
 
-    // TODO 커뮤니티 목록 제공 api 추가
-
-//    @GetMapping(path = "/communities/{c_id}/unanswered-questions")
-//    public ResponseEntity<?> unansweredQuestionList(
-//            @PathVariable("c_id") Long c_id) {
-//        var response = questionService.getUnAnsweredQuestions(c_id);
-//        return ResponseDto.ok(response);
-//    }
-//
-//    @GetMapping(path = "/communities/{c_id}/questions")
-//    public ResponseEntity<?> allQuestionList(
-//            @PathVariable("c_id") Long c_id
-//    ) {
-//        var response = questionService.getAllQuestions(c_id);
-//        return ResponseDto.ok(response);
-//    }
+    @GetMapping(path = "/{q_id}/my-communities")
+    public ResponseEntity<?> getMyCommunities(
+            @PathVariable("q_id") Long q_id
+    ) {
+        List<CommunityInfoResponse> responses = questionService.getMyCommunities(q_id);
+        return ResponseDto.ok(responses);
+    }
 
 }

--- a/src/main/java/com/hanshin/supernova/question/presentation/QuestionListController.java
+++ b/src/main/java/com/hanshin/supernova/question/presentation/QuestionListController.java
@@ -1,0 +1,63 @@
+package com.hanshin.supernova.question.presentation;
+
+import com.hanshin.supernova.common.model.ResponseDto;
+import com.hanshin.supernova.question.application.QuestionListService;
+import com.hanshin.supernova.question.dto.response.QuestionInfoResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/communities/{c_id}")
+@RequiredArgsConstructor
+public class QuestionListController {
+
+    private final QuestionListService questionListService;
+
+    @GetMapping(path = "/all-latest-questions")
+    public ResponseEntity<?> allLatestQuestions(
+            @PathVariable("c_id") Long cId
+    ) {
+        var response = questionListService.getAllQuestionsByDesc(cId);
+        return ResponseDto.ok(response);
+    }
+
+    @GetMapping(path = "/all-old-questions")
+    public ResponseEntity<?> allOldQuestions(
+            @PathVariable("c_id") Long cId
+    ) {
+        var response = questionListService.getAllQuestionsByAsc(cId);
+        return ResponseDto.ok(response);
+    }
+
+    @GetMapping(path = "/unanswered-latest-questions")
+    public ResponseEntity<?> unansweredLatestQuestions(
+            @PathVariable("c_id") Long cId
+    ) {
+        List<QuestionInfoResponse> responses = questionListService.getUnAnsweredQuestionsByDesc(
+                cId);
+        return ResponseDto.ok(responses);
+    }
+
+    @GetMapping(path = "/unanswered-old-questions")
+    public ResponseEntity<?> unansweredOldQuestions(
+            @PathVariable("c_id") Long cId
+    ) {
+        List<QuestionInfoResponse> responses = questionListService.getUnAnsweredQuestionsByAsc(
+                cId);
+        return ResponseDto.ok(responses);
+    }
+
+    @GetMapping(path = "/unanswered-latest-4-questions")
+    public ResponseEntity<?> unansweredLatest4Questions(
+            @PathVariable("c_id") Long cId
+    ) {
+        List<QuestionInfoResponse> responses = questionListService.getUnAnswered4QuestionsByDesc(
+                cId, 4);
+        return ResponseDto.ok(responses);
+    }
+}


### PR DESCRIPTION
<!--
제목은 다음과 같이 정합니다.
domain: 진행한 내용 요약
domain -> feat / error / ect
+ 필요 없는 내용은 지워주세요.
-->

## 🚀 연관된 이슈

- resolve: #7 

## ✨ 작업 내용

- 질문의 기본 목록 조회 기능 구현