### PR TITLE
feat: 알림 crud + L 기능 구현

### DIFF
--- a/src/main/java/com/hanshin/supernova/community/application/CommunityService.java
+++ b/src/main/java/com/hanshin/supernova/community/application/CommunityService.java
@@ -1,6 +1,6 @@
 package com.hanshin.supernova.community.application;
 
-import static com.hanshin.supernova.exception.dto.ErrorType.NON_ADMIN_AUTH_ERROR;
+import static com.hanshin.supernova.exception.dto.ErrorType.ONLY_ADMIN_AUTHORITY_ERROR;
 
 import com.hanshin.supernova.common.dto.SuccessResponse;
 import com.hanshin.supernova.community.domain.Autority;
@@ -210,7 +210,7 @@ public class CommunityService {
 
     private static void isCommunityCreator(Community findCommunity, Long userId) {
         if (!findCommunity.getCreatedBy().equals(userId)) {
-            throw new CommunityInvalidException(NON_ADMIN_AUTH_ERROR);
+            throw new CommunityInvalidException(ONLY_ADMIN_AUTHORITY_ERROR);
         }
     }
 

--- a/src/main/java/com/hanshin/supernova/exception/dto/ErrorType.java
+++ b/src/main/java/com/hanshin/supernova/exception/dto/ErrorType.java
@@ -36,23 +36,11 @@ public enum ErrorType {
     USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     FAIL_TO_LOGIN_ERROR(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),
-  
+
     // 질문 예외
     QUESTION_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "id에 해당하는 질문이 존재하지 않습니다."),
     NEITHER_BLANK_ERROR(HttpStatus.BAD_REQUEST, "제목과 내용은 빈 문자열일 수 없습니다."),
-    QUESTION_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "id에 해당하는 질문이 존재하지 않습니다."),
 
-    // 토큰 오류
-    AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "인증, 인가 오류"),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "해당 토큰은 만료된 토큰입니다."),
-    NULL_TOKEN(HttpStatus.UNAUTHORIZED, "access token 이 존재하지 않습니다."),
-    TOKEN_BLACKLISTED(HttpStatus.BAD_REQUEST, "해당 토큰은 이미 로그아웃 되었습니다."),
-
-    // 로그인 오류
-    USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
-    FAIL_TO_LOGIN_ERROR(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),
-  
     // 답변 예외
     ANSWER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "id에 해당하는 답변이 존재하지 않습니다."),
 

--- a/src/main/java/com/hanshin/supernova/exception/dto/ErrorType.java
+++ b/src/main/java/com/hanshin/supernova/exception/dto/ErrorType.java
@@ -21,10 +21,13 @@ public enum ErrorType {
     NON_IDENTICAL_COMMUNITY_CREATOR_ERROR(HttpStatus.FORBIDDEN, "커뮤니티의 생성자가 아닙니다."),
 
     // admin 예외
-    NON_ADMIN_AUTH_ERROR(HttpStatus.FORBIDDEN, "관리자 권한이 필요한 서비스 입니다."),
+    ONLY_ADMIN_AUTHORITY_ERROR(HttpStatus.BAD_REQUEST, "관리자 권한이 필요한 기능입니다."),
 
     // auth 예외
     NON_IDENTICAL_USER_ERROR(HttpStatus.FORBIDDEN, "작성자와 접근자가 일치하지 않습니다."),
+
+    // user 예외
+    SYSTEM_USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "시스템 유저를 찾을 수 없습니다."),
 
     // 토큰 오류
     AUTHORIZATION_ERROR(HttpStatus.UNAUTHORIZED, "인증, 인가 오류"),
@@ -46,7 +49,11 @@ public enum ErrorType {
 
     // 해시태그 예외
     HASHTAG_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "id 에 해당하는 해시태그가 존재하지 않습니다."),
-    HASHTAG_MAX_SIZE_5_ERROR(HttpStatus.BAD_REQUEST, "해시태그는 최대 5개까지 등록 가능합니다.");
+    HASHTAG_MAX_SIZE_5_ERROR(HttpStatus.BAD_REQUEST, "해시태그는 최대 5개까지 등록 가능합니다."),
+
+    // 알림 예외
+    NOT_RECEIVER_ERROR(HttpStatus.BAD_REQUEST, "알림을 수신하는 당사자가 아닙니다."),
+    NEWS_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "id 에 맞는 알림이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/hanshin/supernova/exception/news/NewsInvalidException.java
+++ b/src/main/java/com/hanshin/supernova/exception/news/NewsInvalidException.java
@@ -1,0 +1,11 @@
+package com.hanshin.supernova.exception.news;
+
+import com.hanshin.supernova.exception.BusinessException;
+import com.hanshin.supernova.exception.dto.ErrorType;
+
+public class NewsInvalidException extends BusinessException {
+
+    public NewsInvalidException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/hanshin/supernova/exception/user/UserInvalidException.java
+++ b/src/main/java/com/hanshin/supernova/exception/user/UserInvalidException.java
@@ -1,0 +1,11 @@
+package com.hanshin.supernova.exception.user;
+
+import com.hanshin.supernova.exception.BusinessException;
+import com.hanshin.supernova.exception.dto.ErrorType;
+
+public class UserInvalidException extends BusinessException {
+
+    public UserInvalidException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/hanshin/supernova/news/application/NewsService.java
+++ b/src/main/java/com/hanshin/supernova/news/application/NewsService.java
@@ -1,0 +1,153 @@
+package com.hanshin.supernova.news.application;
+
+
+import com.hanshin.supernova.auth.model.AuthUser;
+import com.hanshin.supernova.common.dto.SuccessResponse;
+import com.hanshin.supernova.exception.auth.AuthInvalidException;
+import com.hanshin.supernova.exception.dto.ErrorType;
+import com.hanshin.supernova.exception.news.NewsInvalidException;
+import com.hanshin.supernova.exception.user.UserInvalidException;
+import com.hanshin.supernova.news.domain.News;
+import com.hanshin.supernova.news.dto.request.NewsRequest;
+import com.hanshin.supernova.news.dto.response.NewsResponse;
+import com.hanshin.supernova.news.infrastructure.NewsRepository;
+import com.hanshin.supernova.user.domain.Authority;
+import com.hanshin.supernova.user.domain.User;
+import com.hanshin.supernova.user.infrastructure.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+
+    private final NewsRepository newsRepository;
+    private final UserRepository userRepository;
+
+    public NewsResponse createNews(NewsRequest request) {
+        getUserOrThrowIfNotExist(request.getReceiverId());
+
+        News savedNews = buildAndSaveNews(request);
+
+        return NewsResponse.toResponse(
+                savedNews.getId(), savedNews.getTitle(), savedNews.getContent(),
+                savedNews.getType(), savedNews.isViewed(), savedNews.getCreatedAt(),
+                savedNews.isHasRelatedContent(), savedNews.getRelatedContentId());
+    }
+
+    public NewsResponse getNews(AuthUser user, Long newsId) {
+        News findNews = getNewsOrThrowIfNotExist(newsId);
+
+        // 알림에 접근하는 사용자와 알림 수신자가 일치하는지 검증
+        verifyReceiver(user.getId(), findNews);
+
+        // 조회한 적 없는 알림의 경우 조회한 상태로 변경
+        if (!findNews.isViewed()) {
+            findNews.changeViewed();
+        }
+
+        return NewsResponse.toResponse(
+                findNews.getId(), findNews.getTitle(), findNews.getContent(),
+                findNews.getType(), findNews.isViewed(), findNews.getCreatedAt(),
+                findNews.isHasRelatedContent(), findNews.getRelatedContentId()
+        );
+    }
+
+    public NewsResponse updateNews(AuthUser user, Long newsId, NewsRequest request) {
+        News findNews = getNewsOrThrowIfNotExist(newsId);
+
+        User findUser = getUserOrThrowIfNotExist(user.getId());
+
+        // 관리자 권한 검증
+        verifyAdmin(findUser);
+
+        findNews.update(request.getTitle(), request.getContent(), request.getType(),
+                request.isHasRelatedContent(), request.getRelatedContentId());
+
+        return NewsResponse.toResponse(
+                findNews.getId(), findNews.getTitle(), findNews.getContent(),
+                findNews.getType(), findNews.isViewed(), findNews.getCreatedAt(),
+                findNews.isHasRelatedContent(), findNews.getRelatedContentId()
+        );
+    }
+
+    public SuccessResponse deleteNews(AuthUser user, Long newsId) {
+        User findUser = getUserOrThrowIfNotExist(user.getId());
+
+        verifyAdmin(findUser);
+
+        newsRepository.deleteById(newsId);
+
+        return new SuccessResponse("알림 삭제 완료");
+    }
+
+    public List<NewsResponse> getUnViewedNews(AuthUser user) {
+        List<News> findNewsList = newsRepository.findAllByReceiverIdAndIsViewedFalseOrderByCreatedAtDesc(
+                user.getId());
+
+        return getNewsResponses(findNewsList);
+    }
+
+    public List<NewsResponse> getViewedNews(AuthUser user) {
+        List<News> findNewsList = newsRepository.findAllByReceiverIdAndIsViewedTrueOrderByCreatedAtDesc(
+                user.getId());
+
+        return getNewsResponses(findNewsList);
+    }
+
+
+    private User getUserOrThrowIfNotExist(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new UserInvalidException(ErrorType.USER_NOT_FOUND_ERROR)
+        );
+    }
+
+    private News getNewsOrThrowIfNotExist(Long newsId) {
+        return newsRepository.findById(newsId).orElseThrow(
+                () -> new NewsInvalidException(ErrorType.NEWS_NOT_FOUND_ERROR));
+    }
+
+    private static void verifyReceiver(Long userId, News findNews) {
+        if (!findNews.getReceiverId().equals(userId)) {
+            throw new UserInvalidException(ErrorType.NOT_RECEIVER_ERROR);
+        }
+    }
+
+    private static void verifyAdmin(User user) {
+        if (!user.getAuthority().equals(Authority.ADMIN)) {
+            throw new AuthInvalidException(ErrorType.ONLY_ADMIN_AUTHORITY_ERROR);
+        }
+    }
+
+    private News buildAndSaveNews(NewsRequest request) {
+        User systemUser = userRepository.findByAuthority(Authority.SYSTEM)
+                .orElseThrow(() -> new NewsInvalidException(ErrorType.SYSTEM_USER_NOT_FOUND_ERROR));
+
+        News news = News.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .type(request.getType())
+                .isViewed(false)
+                .senderId(systemUser.getId())
+                .receiverId(request.getReceiverId())
+                .hasRelatedContent(request.isHasRelatedContent())
+                .relatedContentId(request.getRelatedContentId())
+                .build();
+        return newsRepository.save(news);
+    }
+
+    private List<NewsResponse> getNewsResponses(List<News> findNewsList) {
+        List<NewsResponse> responseList = new ArrayList<>();
+        findNewsList.forEach(news -> {
+            responseList.add(
+                    NewsResponse.toResponse(news.getId(), news.getTitle(), news.getContent(),
+                            news.getType(), news.isViewed(), news.getCreatedAt(),
+                            news.isHasRelatedContent(), news.getRelatedContentId())
+            );
+        });
+
+        return responseList;
+    }
+}

--- a/src/main/java/com/hanshin/supernova/news/domain/News.java
+++ b/src/main/java/com/hanshin/supernova/news/domain/News.java
@@ -1,0 +1,64 @@
+package com.hanshin.supernova.news.domain;
+
+import com.hanshin.supernova.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class News extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @Enumerated
+    private Type type;
+
+    @Column(name = "is_viewed")
+    private boolean isViewed;
+
+    @Column(name = "sender_id")
+    private Long senderId;
+
+    @Column(name = "receiver_id")
+    private Long receiverId;
+
+    @Column(name = "has_related_content")
+    private boolean hasRelatedContent;
+
+    @Column(name = "related_content_id")
+    private Long relatedContentId;
+
+    public void update(String title, String content, Type type, boolean hasRelatedContent, Long relatedContentId) {
+        this.title = title;
+        this.content = content;
+        this.type = type;
+        this.hasRelatedContent = hasRelatedContent;
+        this.relatedContentId = relatedContentId;
+    }
+
+    public void changeViewed() {
+        this.isViewed = true;
+    }
+
+    // 수신인 변경: 관리자 페이지에서 가능하다.
+//    public void changeReciever(Long recieverId) {
+//        this.recieverId = recieverId;
+//    }
+}

--- a/src/main/java/com/hanshin/supernova/news/domain/Type.java
+++ b/src/main/java/com/hanshin/supernova/news/domain/Type.java
@@ -1,0 +1,5 @@
+package com.hanshin.supernova.news.domain;
+
+public enum Type {
+    AUTHORITY, COMMUNITY, QUESTION, ANSWER, BADGE
+}

--- a/src/main/java/com/hanshin/supernova/news/dto/request/NewsRequest.java
+++ b/src/main/java/com/hanshin/supernova/news/dto/request/NewsRequest.java
@@ -1,0 +1,32 @@
+package com.hanshin.supernova.news.dto.request;
+
+import com.hanshin.supernova.news.domain.Type;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NewsRequest {
+
+    @NotBlank(message = "알림의 제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "알림의 내용은 필수입니다.")
+    private String content;
+
+    @NotNull(message = "알림의 종류는 필수입니다.")
+    private Type type;
+
+    private boolean hasRelatedContent;
+
+    private Long relatedContentId;
+
+    @NotNull(message = "수신자 지정은 필수입니다.")
+    private Long receiverId;
+}

--- a/src/main/java/com/hanshin/supernova/news/dto/response/NewsResponse.java
+++ b/src/main/java/com/hanshin/supernova/news/dto/response/NewsResponse.java
@@ -1,0 +1,34 @@
+package com.hanshin.supernova.news.dto.response;
+
+import com.hanshin.supernova.news.domain.Type;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class NewsResponse {
+
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private Type type;
+
+    private boolean isViewed;
+
+    private LocalDateTime createdAt;
+
+    private boolean hasRelatedContent;
+
+    private Long relatedContentId;
+
+    public static NewsResponse toResponse(Long id, String title, String content, Type type,
+            boolean isViewed, LocalDateTime createdAt, boolean hasRelatedContent,
+            Long relatedContentId) {
+        return new NewsResponse(id, title, content, type, isViewed, createdAt, hasRelatedContent,
+                relatedContentId);
+    }
+}

--- a/src/main/java/com/hanshin/supernova/news/infrastructure/NewsRepository.java
+++ b/src/main/java/com/hanshin/supernova/news/infrastructure/NewsRepository.java
@@ -1,0 +1,16 @@
+package com.hanshin.supernova.news.infrastructure;
+
+import com.hanshin.supernova.news.domain.News;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public interface NewsRepository extends JpaRepository<News, Long> {
+
+    List<News> findAllByReceiverIdAndIsViewedFalseOrderByCreatedAtDesc(Long userId);
+
+    List<News> findAllByReceiverIdAndIsViewedTrueOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/hanshin/supernova/news/presentation/NewsController.java
+++ b/src/main/java/com/hanshin/supernova/news/presentation/NewsController.java
@@ -1,0 +1,95 @@
+package com.hanshin.supernova.news.presentation;
+
+import com.hanshin.supernova.auth.model.AuthUser;
+import com.hanshin.supernova.common.model.ResponseDto;
+import com.hanshin.supernova.news.application.NewsService;
+import com.hanshin.supernova.news.dto.request.NewsRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = "/api/news")
+@RequiredArgsConstructor
+public class NewsController {
+    private final NewsService newsService;
+
+    /**
+     * 알림 생성: 관리자 또는 시스템만 생성 가능하다.
+     */
+    @PostMapping
+    public ResponseEntity<?> createNews(
+            @RequestBody @Valid NewsRequest request
+    ) {
+        var response = newsService.createNews(request);
+        return ResponseDto.created(response);
+    }
+
+    /**
+     * 알림 조회: 당사자만 조회 가능하다.
+     */
+    @GetMapping(path = "/{newsId}")
+    public ResponseEntity<?> getNews(
+            AuthUser user,
+            @PathVariable(name = "newsId") Long newsId
+    ) {
+        var response = newsService.getNews(user, newsId);
+        return ResponseDto.ok(response);
+    }
+
+    /**
+     * 알림 수정: 관리자만 수정 가능하다.
+     */
+    @PutMapping(path = "/{newsId}")
+    public ResponseEntity<?> updateNews(
+            AuthUser user,
+            @PathVariable(name = "newsId") Long newsId,
+            @RequestBody @Valid NewsRequest request
+    ) {
+        var response = newsService.updateNews(user, newsId, request);
+        return ResponseDto.ok(response);
+    }
+
+    /**
+     * 알림 삭제: 관리자만 삭제 가능하다.
+     */
+    @DeleteMapping(path = "/{newsId}")
+    public ResponseEntity<?> deleteNews(
+            AuthUser user,
+            @PathVariable(name = "newsId") Long newsId
+    ) {
+        var response = newsService.deleteNews(user, newsId);
+        return ResponseDto.ok(response);
+    }
+
+    /**
+     * 확인되지 않은 알림 목록
+     */
+    @GetMapping(path = "/unviewed-list")
+    public ResponseEntity<?> getUnViewedNews(
+            AuthUser user
+    ) {
+        var responses = newsService.getUnViewedNews(user);
+        return ResponseDto.ok(responses);
+    }
+
+    /**
+     * 확인된 알림 목록
+     */
+    @GetMapping(path = "/viewed-list")
+    public ResponseEntity<?> getViewedNews(
+            AuthUser user
+    ) {
+        var responses = newsService.getViewedNews(user);
+        return ResponseDto.ok(responses);
+    }
+
+}

--- a/src/main/java/com/hanshin/supernova/user/application/UserService.java
+++ b/src/main/java/com/hanshin/supernova/user/application/UserService.java
@@ -38,6 +38,7 @@ public class UserService {
                 .password(request.getPassword())
                 .username(request.getNickname())
                 .nickname(request.getNickname())
+                .authority(request.getAuthority())
                 .build();
 
         User savedUser = userRepository.save(user);

--- a/src/main/java/com/hanshin/supernova/user/domain/Authority.java
+++ b/src/main/java/com/hanshin/supernova/user/domain/Authority.java
@@ -1,0 +1,6 @@
+package com.hanshin.supernova.user.domain;
+
+public enum Authority {
+
+    USER, ADMIN, SYSTEM
+}

--- a/src/main/java/com/hanshin/supernova/user/domain/User.java
+++ b/src/main/java/com/hanshin/supernova/user/domain/User.java
@@ -28,6 +28,9 @@ public class User extends BaseEntity {
     @Column(name = "nickname", unique = true)
     private String nickname;
 
+    @Enumerated
+    private Authority authority;
+
     @Embedded
     private Activity activity;
 

--- a/src/main/java/com/hanshin/supernova/user/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/hanshin/supernova/user/dto/request/UserRegisterRequest.java
@@ -1,5 +1,6 @@
 package com.hanshin.supernova.user.dto.request;
 
+import com.hanshin.supernova.user.domain.Authority;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -20,4 +21,7 @@ public class UserRegisterRequest {
     @NotNull(message = "닉네임은 필수입니다.")
     @Size(max = 10, message = "닉네임은 최대 10글자 입니다.")
     private String nickname;
+
+    @NotNull(message = "사용자의 권한 설정은 필수입니다. 일반 사용자의 경우 'USER' 권한으로 추가해주세요.")
+    private Authority authority;
 }

--- a/src/main/java/com/hanshin/supernova/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/hanshin/supernova/user/infrastructure/UserRepository.java
@@ -1,5 +1,6 @@
 package com.hanshin.supernova.user.infrastructure;
 
+import com.hanshin.supernova.user.domain.Authority;
 import com.hanshin.supernova.user.domain.User;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -18,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByAuthority(Authority authority);
 }


### PR DESCRIPTION
<!--
제목은 다음과 같이 정합니다.
domain: 진행한 내용 요약
domain -> feat / error / ect
+ 필요 없는 내용은 지워주세요.
-->

## 🚀 연관된 이슈

- resolve: #32 

## ✨ 작업 내용

- 알림 crud 및 사용자의 확인 여부에 따른 목록 조회 기능을 구현했습니다.

## 💬 리뷰 요구사항(선택)

- User 도메인에 Authority 를 추가 및 연관 코드인 UserService 에서 Authority 를 빌드에 추가했습니다.
- 이후 해당 코드를 pull 한 뒤 다시 실행했을 때, db 오류가 난다면 해당 db의 테이블을 drop 하고 다시 실행해주세요!
- 추후 프론트에서는 현재와 같이 정보를 받되, 백엔드로 해당 데이터를 보낼 때 authority 를 'USER'로 설정하여 함께 전달해주세요.