### PR TITLE
feat: 커뮤니티 및 질문 이미지 업로드

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,3 @@ local.properties
 
 ### environment ###
 *.env
-
-### application
-application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     // redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis:2.7.7")
 
+	// s3
+	implementation("io.awspring.cloud:spring-cloud-aws-s3:3.0.2")
+
 	// json
 	implementation group: 'org.json', name: 'json', version: '20090211'
 	implementation 'com.googlecode.json-simple:json-simple:1.1'

--- a/src/main/java/com/hanshin/supernova/community/application/CommunityService.java
+++ b/src/main/java/com/hanshin/supernova/community/application/CommunityService.java
@@ -53,6 +53,7 @@ public class CommunityService extends AbstractValidateService {
                 savedCommunity.getId(),
                 savedCommunity.getName(),
                 savedCommunity.getDescription(),
+                savedCommunity.getImgUrl(),
                 savedCommunity.getCreatedAt(),
                 savedCommunity.isVisible(),
                 savedCommunity.isPublic(),
@@ -78,6 +79,7 @@ public class CommunityService extends AbstractValidateService {
                 findCommunity.getId(),
                 findCommunity.getName(),
                 findCommunity.getDescription(),
+                findCommunity.getImgUrl(),
                 findCommunity.getCreatedAt(),
                 findCommunity.isVisible(),
                 findCommunity.isPublic(),
@@ -112,6 +114,7 @@ public class CommunityService extends AbstractValidateService {
                 findCommunity.getId(),
                 findCommunity.getName(),
                 findCommunity.getDescription(),
+                findCommunity.getImgUrl(),
                 findCommunity.getCreatedAt(),
                 findCommunity.isVisible(),
                 findCommunity.isPublic(),
@@ -174,6 +177,7 @@ public class CommunityService extends AbstractValidateService {
         return Community.builder()
                 .name(request.getName())
                 .description(request.getDescription())
+                .imgUrl(request.getImgUrl())
                 .isVisible(request.isVisible())
                 .isPublic(request.isPublic())
                 .isDormant(false)
@@ -196,6 +200,7 @@ public class CommunityService extends AbstractValidateService {
         findCommunity.update(
                 request.getName(),
                 request.getDescription(),
+                request.getImgUrl(),
                 request.isVisible(),
                 request.isPublic());
     }
@@ -216,7 +221,8 @@ public class CommunityService extends AbstractValidateService {
                     CommunityInfoResponse.toResponse(
                             community.getId(),
                             community.getName(),
-                            community.getCommCounter().getMemberCnt()
+                            community.getCommCounter().getMemberCnt(),
+                            community.getImgUrl()
                     )
             );
         });

--- a/src/main/java/com/hanshin/supernova/community/domain/Community.java
+++ b/src/main/java/com/hanshin/supernova/community/domain/Community.java
@@ -30,7 +30,8 @@ public class Community extends BaseEntity {
 
     private String description;
 
-//    private MultipartFile profileImg;  // 커뮤니티 프로필 이미지
+    @Column(name = "img_url")
+    private String imgUrl;  // 커뮤니티 프로필 이미지
 
     @Column(name = "is_visible")
     private boolean isVisible; // 외부인의 조회 가능 여부
@@ -48,9 +49,10 @@ public class Community extends BaseEntity {
     private CommCounter commCounter;
 
     public void update(
-            String name, String description, boolean isVisible, boolean isPublic) {
+            String name, String description, String imgUrl, boolean isVisible, boolean isPublic) {
         this.name = name;
         this.description = description;
+        this.imgUrl = imgUrl;
         this.isVisible = isVisible;
         this.isPublic = isPublic;
     }

--- a/src/main/java/com/hanshin/supernova/community/dto/request/CommunityRequest.java
+++ b/src/main/java/com/hanshin/supernova/community/dto/request/CommunityRequest.java
@@ -14,7 +14,7 @@ public class CommunityRequest {
     @Size(max = 200, message = "소개글은 최대 200자까지 작성 가능합니다.")
     private String description;
 
-    //    private String imageUrl;
+    private String imgUrl;
 
     @JsonProperty("isVisible")
     private boolean isVisible;

--- a/src/main/java/com/hanshin/supernova/community/dto/response/CommunityInfoResponse.java
+++ b/src/main/java/com/hanshin/supernova/community/dto/response/CommunityInfoResponse.java
@@ -10,11 +10,11 @@ public class CommunityInfoResponse {
     private Long id;
     private String name;
     private int userCnt;
-//    private String profileImg;
+    private String imgUrl;
 
     public static CommunityInfoResponse toResponse(
-            Long id, String name, int userCnt
+            Long id, String name, int userCnt, String imgUrl
     ) {
-        return new CommunityInfoResponse(id, name, userCnt);
+        return new CommunityInfoResponse(id, name, userCnt, imgUrl);
     }
 }

--- a/src/main/java/com/hanshin/supernova/community/dto/response/CommunityResponse.java
+++ b/src/main/java/com/hanshin/supernova/community/dto/response/CommunityResponse.java
@@ -16,6 +16,8 @@ public class CommunityResponse {
 
     private String description;
 
+    private String imgUrl;
+
     private LocalDateTime createdAt;
 
     @JsonProperty("isVisible")
@@ -33,13 +35,14 @@ public class CommunityResponse {
             Long id,
             String name,
             String description,
+            String imgUrl,
             LocalDateTime createdAt,
             boolean isVisible,
             boolean isPublic,
             boolean isDormant,
             CommCounter commCounter
     ) {
-        return new CommunityResponse(id, name, description, createdAt, isVisible, isPublic,
+        return new CommunityResponse(id, name, description, imgUrl, createdAt, isVisible, isPublic,
                 isDormant, commCounter);
     }
 }

--- a/src/main/java/com/hanshin/supernova/exception/dto/ErrorType.java
+++ b/src/main/java/com/hanshin/supernova/exception/dto/ErrorType.java
@@ -56,6 +56,10 @@ public enum ErrorType {
     ACCEPTED_ANSWER_CANNOT_BE_EDITED_ERROR(HttpStatus.BAD_REQUEST, "채택된 답변은 수정이 불가능합니다."),
     QUESTIONER_CANNOT_ACCEPT_THEIR_OWN_ANSWER_ERROR(HttpStatus.BAD_REQUEST, "게시글 당사자는 자신의 댓글 채택이 불가능합니다."),
 
+    // S3 예외
+    EMPTY_IMAGE_ERROR(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),
+    IMAGE_UPLOAD_FAILED_ERROR(HttpStatus.BAD_REQUEST, "이미지 업로드에 실패하였습니다."),
+
     // rate limit 예외
     RATE_LIMIT_EXCEEDED_ERROR(HttpStatus.TOO_MANY_REQUESTS, "요청 횟수가 한계를 초과하였습니다."),
 

--- a/src/main/java/com/hanshin/supernova/exception/s3/S3InvalidException.java
+++ b/src/main/java/com/hanshin/supernova/exception/s3/S3InvalidException.java
@@ -1,0 +1,11 @@
+package com.hanshin.supernova.exception.s3;
+
+import com.hanshin.supernova.exception.BusinessException;
+import com.hanshin.supernova.exception.dto.ErrorType;
+
+public class S3InvalidException extends BusinessException {
+
+    public S3InvalidException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/hanshin/supernova/question/application/QuestionService.java
+++ b/src/main/java/com/hanshin/supernova/question/application/QuestionService.java
@@ -110,7 +110,7 @@ public class QuestionService extends AbstractValidateService {
 
         validateSameQuestionerById(findQuestion, findUser.getId());
 
-        findQuestion.updateQuestion(request.getTitle(), request.getContent(),
+        findQuestion.updateQuestion(request.getTitle(), request.getContent(), request.getImgUrl(),
                 findCommunity.getId());
 
         // TODO ContentWord update logic
@@ -214,6 +214,7 @@ public class QuestionService extends AbstractValidateService {
         return QuestionResponse.toResponse(
                 findQuestion.getTitle(),
                 findQuestion.getContent(),
+                findQuestion.getImgUrl(),
                 findQuestion.isResolved(),
                 findQuestion.getCreatedAt(),
                 findQuestion.getModifiedAt(),

--- a/src/main/java/com/hanshin/supernova/question/application/QuestionService.java
+++ b/src/main/java/com/hanshin/supernova/question/application/QuestionService.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,13 +42,15 @@ public class QuestionService extends AbstractValidateService {
      * 질문 등록
      */
     @Transactional
-    public QuestionSaveResponse createQuestion(AuthUser user, QuestionRequest request) {
+    public QuestionSaveResponse createQuestion(AuthUser user,
+            QuestionRequest request) {
         Community findCommunity = getCommunityOrThrowIfNotExist(request.getCommId());
         User findUser = getUserOrThrowIfNotExist(user.getId());
 
         Question question = Question.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
+                .imgUrl(request.getImgUrl())
                 .questionerId(findUser.getId())
                 .commId(findCommunity.getId())
                 .build();
@@ -109,7 +110,8 @@ public class QuestionService extends AbstractValidateService {
 
         validateSameQuestionerById(findQuestion, findUser.getId());
 
-        findQuestion.updateQuestion(request.getTitle(), request.getContent(), findCommunity.getId());
+        findQuestion.updateQuestion(request.getTitle(), request.getContent(),
+                findCommunity.getId());
 
         // TODO ContentWord update logic
 
@@ -150,7 +152,7 @@ public class QuestionService extends AbstractValidateService {
         Question findQuestion = getQuestionById(qId);
         User findUser = getUserOrThrowIfNotExist(user.getId());
         // 자신의 질문은 추천하지 못하도록 예외처리
-        if(findQuestion.getQuestionerId().equals(findUser.getId())) {
+        if (findQuestion.getQuestionerId().equals(findUser.getId())) {
             throw new AuthInvalidException(ErrorType.WRITER_CANNOT_RECOMMEND_ERROR);
         }
         // 기존 추천한 이력 유무에 따른 추천수 증감

--- a/src/main/java/com/hanshin/supernova/question/domain/Question.java
+++ b/src/main/java/com/hanshin/supernova/question/domain/Question.java
@@ -29,10 +29,10 @@ public class Question extends BaseEntity {
 
     // 콘텐츠 정보
     private String title;
-
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
-
+    @Column(name = "img_url")
+    private String imgUrl;
     private boolean isResolved;
 
     // cnt 정보

--- a/src/main/java/com/hanshin/supernova/question/domain/Question.java
+++ b/src/main/java/com/hanshin/supernova/question/domain/Question.java
@@ -49,9 +49,10 @@ public class Question extends BaseEntity {
     @Column(name = "comm_id")
     private Long commId;
 
-    public void updateQuestion(String title, String content, Long commId) {
+    public void updateQuestion(String title, String content, String imgUrl, Long commId) {
         this.title = title;
         this.content = content;
+        this.imgUrl = imgUrl;
         this.commId = commId;
     }
 

--- a/src/main/java/com/hanshin/supernova/question/dto/request/QuestionRequest.java
+++ b/src/main/java/com/hanshin/supernova/question/dto/request/QuestionRequest.java
@@ -17,6 +17,8 @@ public class QuestionRequest {
     @NotBlank(message = "내용은 필수입니다.")
     private String content;
 
+    private String imgUrl;
+
     @NotNull(message = "커뮤니티 선택은 필수입니다.")
     private Long commId;
 

--- a/src/main/java/com/hanshin/supernova/question/dto/response/QuestionResponse.java
+++ b/src/main/java/com/hanshin/supernova/question/dto/response/QuestionResponse.java
@@ -11,6 +11,7 @@ public class QuestionResponse {
 
     private String title;
     private String content;
+    private String imgUrl;
     private boolean isResolved;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
@@ -24,6 +25,7 @@ public class QuestionResponse {
     public static QuestionResponse toResponse(
             String title,
             String content,
+            String imgUrl,
             boolean isResolved,
             LocalDateTime createdAt,
             LocalDateTime modifiedAt,
@@ -34,7 +36,7 @@ public class QuestionResponse {
             String commName,
             String questionerName
     ) {
-        return new QuestionResponse(title, content, isResolved, createdAt, modifiedAt, viewCnt,
+        return new QuestionResponse(title, content, imgUrl, isResolved, createdAt, modifiedAt, viewCnt,
                 recCnt, commId, questionerId, commName, questionerName);
     }
 }

--- a/src/main/java/com/hanshin/supernova/s3/application/S3Uploader.java
+++ b/src/main/java/com/hanshin/supernova/s3/application/S3Uploader.java
@@ -1,0 +1,63 @@
+package com.hanshin.supernova.s3.application;
+
+import com.hanshin.supernova.s3.utils.CommonUtils;
+import java.io.IOException;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Uploader {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile multipartFile) {
+
+        if (multipartFile.isEmpty()) {
+            log.info("image is null");
+            return "";
+        }
+
+        String fileName = getFileName(multipartFile);
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .contentType(multipartFile.getContentType())
+                    .contentLength(multipartFile.getSize())
+                    .key(fileName)
+                    .build();
+            RequestBody requestBody = RequestBody.fromBytes(multipartFile.getBytes());
+            s3Client.putObject(putObjectRequest, requestBody);
+        } catch (IOException e) {
+            log.error("cannot upload image", e);
+            throw new RuntimeException(e);
+        }
+        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        return s3Client.utilities().getUrl(getUrlRequest).toString();
+    }
+
+    public String getFileName(MultipartFile multipartFile) {
+        if (multipartFile.isEmpty()) {
+            return "";
+        }
+        return CommonUtils.buildFileName(
+                Objects.requireNonNull(multipartFile.getOriginalFilename()));
+    }
+}

--- a/src/main/java/com/hanshin/supernova/s3/config/S3Config.java
+++ b/src/main/java/com/hanshin/supernova/s3/config/S3Config.java
@@ -1,0 +1,45 @@
+package com.hanshin.supernova.s3.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Slf4j
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(this::awsCredentials)
+                .region(Region.of(region))
+                .build();
+    }
+
+    private AwsCredentials awsCredentials() {
+        return new AwsCredentials() {
+            @Override
+            public String accessKeyId() {
+                return accessKey;
+            }
+
+            @Override
+            public String secretAccessKey() {
+                return secretKey;
+            }
+        };
+    }
+}

--- a/src/main/java/com/hanshin/supernova/s3/presentation/S3Controller.java
+++ b/src/main/java/com/hanshin/supernova/s3/presentation/S3Controller.java
@@ -3,6 +3,8 @@ package com.hanshin.supernova.s3.presentation;
 import static com.hanshin.supernova.common.CrossOriginConstants.CROSS_ORIGIN_ADDRESS;
 
 import com.hanshin.supernova.common.model.ResponseDto;
+import com.hanshin.supernova.exception.dto.ErrorType;
+import com.hanshin.supernova.exception.s3.S3InvalidException;
 import com.hanshin.supernova.s3.application.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +27,16 @@ public class S3Controller {
 
     @PostMapping
     public ResponseEntity<?> uploadImage(@RequestParam("image") MultipartFile image) {
-        String savedFileName = s3Uploader.uploadFile(image);
-        return ResponseDto.ok(savedFileName);
+        try {
+            String fileUrl = s3Uploader.uploadFile(image);
+            if (fileUrl.isEmpty()) {
+                throw new S3InvalidException(ErrorType.EMPTY_IMAGE_ERROR);
+            }
+            log.info("Successfully uploaded image. URL: {}", fileUrl);
+            return ResponseDto.ok(fileUrl);
+        } catch (Exception e) {
+            log.error("Failed to upload image", e);
+            throw new S3InvalidException(ErrorType.IMAGE_UPLOAD_FAILED_ERROR);
+        }
     }
 }

--- a/src/main/java/com/hanshin/supernova/s3/presentation/S3Controller.java
+++ b/src/main/java/com/hanshin/supernova/s3/presentation/S3Controller.java
@@ -1,0 +1,31 @@
+package com.hanshin.supernova.s3.presentation;
+
+import static com.hanshin.supernova.common.CrossOriginConstants.CROSS_ORIGIN_ADDRESS;
+
+import com.hanshin.supernova.common.model.ResponseDto;
+import com.hanshin.supernova.s3.application.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@CrossOrigin(origins = CROSS_ORIGIN_ADDRESS)
+@Slf4j
+@RestController
+@RequestMapping(path = "/api/images")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3Uploader s3Uploader;
+
+    @PostMapping
+    public ResponseEntity<?> uploadImage(@RequestParam("image") MultipartFile image) {
+        String savedFileName = s3Uploader.uploadFile(image);
+        return ResponseDto.ok(savedFileName);
+    }
+}

--- a/src/main/java/com/hanshin/supernova/s3/utils/CommonUtils.java
+++ b/src/main/java/com/hanshin/supernova/s3/utils/CommonUtils.java
@@ -1,0 +1,19 @@
+package com.hanshin.supernova.s3.utils;
+
+public class CommonUtils {
+    public static final String FILE_EXTENSION_SEPARATOR = ".";
+
+    public static String getFileName(String originalFileName) {
+        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR);
+        return originalFileName.substring(0, fileExtensionIndex); //파일 이름
+    }
+
+    public static String buildFileName(String originalFileName) {
+        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); //파일 확장자 구분선
+        String fileExtension = originalFileName.substring(fileExtensionIndex); //파일 확장자
+        String fileName = originalFileName.substring(0, fileExtensionIndex); //파일 이름
+        String now = String.valueOf(System.currentTimeMillis()); //파일 업로드 시간
+
+        return fileName + "_" + now + fileExtension;
+    }
+}

--- a/src/main/java/com/hanshin/supernova/s3/utils/CommonUtils.java
+++ b/src/main/java/com/hanshin/supernova/s3/utils/CommonUtils.java
@@ -1,19 +1,17 @@
 package com.hanshin.supernova.s3.utils;
 
+import java.util.UUID;
+
 public class CommonUtils {
+
     public static final String FILE_EXTENSION_SEPARATOR = ".";
 
-    public static String getFileName(String originalFileName) {
-        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR);
-        return originalFileName.substring(0, fileExtensionIndex); //파일 이름
-    }
-
     public static String buildFileName(String originalFileName) {
-        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); //파일 확장자 구분선
-        String fileExtension = originalFileName.substring(fileExtensionIndex); //파일 확장자
-        String fileName = originalFileName.substring(0, fileExtensionIndex); //파일 이름
-        String now = String.valueOf(System.currentTimeMillis()); //파일 업로드 시간
+        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR);
+        String fileExtension = originalFileName.substring(fileExtensionIndex)
+                .toLowerCase(); // 확장자 소문자로 변환
+        String uuid = UUID.randomUUID().toString();
 
-        return fileName + "_" + now + fileExtension;
+        return uuid + fileExtension;
     }
 }

--- a/src/main/java/com/hanshin/supernova/view_controller/CommunityViewController.java
+++ b/src/main/java/com/hanshin/supernova/view_controller/CommunityViewController.java
@@ -42,6 +42,14 @@ public class CommunityViewController {
         return "community/community_info";
     }
 
+    @GetMapping("/update/{id}")
+    public String communityUpdate(@PathVariable("id") Long id, Model model) {
+        var communityInfo = communityService.getCommunityInfo(id);
+        model.addAttribute("communityId", id);
+        model.addAttribute("community", communityInfo);
+        return "community/community_update";
+    }
+
     @GetMapping("/{communityId}/unanswered-questions")
     public String unansweredQuestions(@PathVariable(name = "communityId") Long communityId, Model model) {
         model.addAttribute("communityId", communityId);

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -10,3 +10,16 @@ spring:
 openai:
   api:
     key: ${OPENAI_API_KEY}
+
+cloud:
+  # S3
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    s3:
+      bucket: ${S3_BUCKET}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -1,0 +1,58 @@
+spring:
+  application:
+    name: supernova
+  servlet:
+    multipart:
+      enabled: true
+  web:
+    resources:
+      static-locations: classpath:/static/,classpath:/public/
+
+  # DB
+  datasource:
+    url: jdbc:mysql://localhost:3306/supernova
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    open-in-view: true
+    hibernate:
+      ddl-auto: update
+      format_sql: true
+    show-sql: true
+    properties:
+      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+  #    database-platform: org.hibernate.dialect.MySQL8InnoDBDialect
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  thymeleaf:
+    prefix: classpath:/templates/
+    suffix: .html
+    cache: false
+
+
+server:
+  port: 8080
+  tomcat:
+    connection-timeout: 30000
+    #    max-threads: 100
+    #    min-spare-threads: 50
+    #    accept-count: 50
+    uri-encoding: UTF-8
+  forward-headers-strategy: framework
+
+jwt:
+  secret:
+    key: daccaf8d974dc147519ea15f6c3ae221b57a6ef8fa7508e7eca7e4acc863a6a2972ffd261e05dbe48479dd8e91186e5aaf720ffc223d29558848ada33ca48e07
+  access:
+    expiration: 3600 # 액세스 토큰 만료 시간 (초 단위)
+  refresh:
+    expiration: 604800 # 리프레시 토큰 만료 시간 (초 단위, 7일)
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace

--- a/src/main/resources/templates/community/community_info.html
+++ b/src/main/resources/templates/community/community_info.html
@@ -262,9 +262,28 @@
         <span id="active-info" class="status-dot"></span>
         <span id="public-info" class="status-dot"></span>
       </div>
-      <img src="https://via.placeholder.com/120" alt="Community Logo">
+      <img src="https://via.placeholder.com/120" alt="커뮤니티 로고" style="
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        object-fit: cover;  /* 이미지 비율 유지 */
+        margin-bottom: 20px;
+      ">
       <p id="communityName"></p>
       <p id="communityDescription"></p>
+
+      <!-- 수정 버튼 추가 -->
+      <button id="editButton" class="edit-btn" style="
+        margin: 10px 0;
+        padding: 8px 20px;
+        background-color: #007bff;
+        color: white;
+        border: none;
+        border-radius: 5px;
+        cursor: pointer;
+      ">수정
+      </button>
+
       <div class="stats">
         <div class="stats-item">
           <span>회원수</span>
@@ -338,6 +357,15 @@
     document.getElementById('createdAt').textContent = 'since ' + new Date(
         communityInfo.createdAt).toLocaleDateString();
 
+    // 이미지 URL 처리 추가
+    const communityImage = document.querySelector('.side-info img');
+    if (communityInfo.imgUrl) {
+      communityImage.src = communityInfo.imgUrl;
+    } else {
+      communityImage.src = 'https://via.placeholder.com/120';  // 기본 이미지
+    }
+    communityImage.alt = `${communityInfo.name} 커뮤니티 이미지`;
+
     // 활성 상태 표시
     const activeInfo = document.getElementById('active-info');
     activeInfo.style.backgroundColor = communityInfo.isDormant ? 'gray' : 'green';
@@ -348,7 +376,7 @@
     publicInfo.style.backgroundColor = communityInfo.isPublic ? 'blue' : 'red';
     publicInfo.title = communityInfo.isPublic ? '공개' : '비공개';
   }
-  
+
   function fetchCommunityVisitCnt(communityId) {
     fetch(url + `/${communityId}/visitors/daily`, {
       method: 'GET',
@@ -395,42 +423,6 @@
     })
     .catch(error => console.error('Error:', error));
   }
-  // function fetchUnansweredQuestions() {
-  //   fetch(`${url}/${communityId}/unanswered-latest-4-questions`, {
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //       'X-QQ-AUTH-TOKEN': token
-  //     }
-  //   })
-  //   .then(response => response.json())
-  //   .then(data => {
-  //     if (data.data) {
-  //       displayUnansweredQuestions(data.data);
-  //     }
-  //   })
-  //   .catch(error => console.error('Error:', error));
-  // }
-
-  // 질문 목록 표시
-  // function displayUnansweredQuestions(questions) {
-  //   const container = document.getElementById('unanswered-questions');
-  //   container.innerHTML = '';
-  //
-  //   questions.forEach(question => {
-  //     const card = document.createElement('div');
-  //     card.className = 'question-card';
-  //     card.innerHTML = `
-  //           <div class="question-title">${question.title}</div>
-  //           <div class="question-preview">${truncateText(question.content, 100)}</div>
-  //       `;
-  //
-  //     card.addEventListener('click', () => {
-  //       window.location.href = `/questions/info/${question.id}`;
-  //     });
-  //
-  //     container.appendChild(card);
-  //   });
-  // }
 
   // 더보기 버튼 이벤트 핸들러
   document.getElementById('unanswered-view-more-btn').addEventListener('click', () => {
@@ -439,7 +431,6 @@
   document.getElementById('all-view-more-btn').addEventListener('click', () => {
     window.location.href = `/communities/${communityId}/all-questions?sort=latest`;
   });
-
 
   // 커뮤니티 인기 질문 목록 로딩
   function fetchPopularQuestions(communityId) {
@@ -495,6 +486,11 @@
       container.appendChild(card);
     });
   }
+
+  // 커뮤니티 수정 버튼 클릭 이벤트
+  document.getElementById('editButton').addEventListener('click', function() {
+    window.location.href = `/communities/update/${communityId}`;
+  });
 
 </script>
 

--- a/src/main/resources/templates/community/community_update.html
+++ b/src/main/resources/templates/community/community_update.html
@@ -3,7 +3,7 @@
 <head th:replace="~{header :: head(additionalStyles=~{::style})}">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>새 커뮤니티 생성</title>
+  <title>커뮤니티 수정</title>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -153,16 +153,15 @@
 <header th:replace="~{header :: header}"></header>
 
 <div class="container">
-  <h1>새 커뮤니티 생성</h1>
+  <h1>커뮤니티 수정</h1>
   <form id="communityForm">
     <!-- 커뮤니티명 입력 -->
     <label for="community-name">커뮤니티명<span class="required">*</span></label>
-    <input type="text" id="community-name" name="name" placeholder="커뮤니티명을 입력하세요" required>
+    <input type="text" id="community-name" name="name" required>
 
     <!-- 설명 입력 -->
     <label for="description">설명<span class="required">*</span></label>
-    <textarea id="description" name="description" placeholder="커뮤니티에 대한 설명을 입력하세요"
-              required></textarea>
+    <textarea id="description" name="description" required></textarea>
     <p class="help-text">커뮤니티 홈 화면/커뮤니티 가입 시 표시되는 설명입니다.</p>
 
     <!-- 커뮤니티 아이콘 -->
@@ -172,29 +171,28 @@
         <img src="https://via.placeholder.com/100" id="icon-preview" alt="커뮤니티 아이콘">
         <input type="file" id="community-icon" accept="image/*">
       </label>
-      커뮤니티를 대표하는 이미지를 등록해주세요.<br>
-      미등록 시, 기본이미지로 설정됩니다.
+      <div>
+        커뮤니티를 대표하는 이미지를 등록해주세요.<br>
+        미등록 시, 기존 이미지가 유지됩니다.
+      </div>
     </div>
 
     <!-- 커뮤니티 설정 -->
     <div class="settings-wrapper">
       <h2>커뮤니티 설정<span class="required">*</span></h2>
       <div class="settings-group">
-        <!-- 커뮤니티 공개 여부 -->
         <div class="settings">
           커뮤니티 공개 여부
           <div class="radio-group">
-            <label><input type="radio" name="visibility" value="public" checked> Public</label>
+            <label><input type="radio" name="visibility" value="public"> Public</label>
             <label><input type="radio" name="visibility" value="private"> Private</label>
           </div>
         </div>
-        <div class="divider"></div> <!-- 구분선 -->
-
-        <!-- 질문/답변 권한 -->
+        <div class="divider"></div>
         <div class="settings">
           질문/답변 권한
           <div class="radio-group">
-            <label><input type="radio" name="access" value="members" checked> Members Only</label>
+            <label><input type="radio" name="access" value="members"> Members Only</label>
             <label><input type="radio" name="access" value="all"> All</label>
           </div>
         </div>
@@ -203,45 +201,83 @@
 
     <!-- 버튼 -->
     <div class="actions">
-      <button type="button" class="cancel-btn">취소</button>
-      <button type="submit" class="submit-btn">생성하기</button>
+      <button type="button" class="cancel-btn" onclick="history.back()">취소</button>
+      <button type="submit" class="submit-btn">수정하기</button>
     </div>
   </form>
 </div>
 
 <footer th:replace="~{footer :: footer}"></footer>
 
-<script src="/js/news.js"></script>
-<script src="/js/question.js"></script>
-<script src="/js/search.js"></script>
-
 <script>
+  const communityId = [[${communityId}]];
+  const token = 'eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuydtOyaqeyekEEiLCJ1aWQiOjJ9.oZzB9H5K81iaQ1qfeA95MfQLMGEpzqxKqWks21qcOR0';
+
+  // 페이지 로드 시 커뮤니티 정보 가져오기
+  document.addEventListener('DOMContentLoaded', function () {
+    fetch(`http://localhost:8080/api/communities/${communityId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-QQ-AUTH-TOKEN': token
+      }
+    })
+    .then(response => response.json())
+    .then(data => {
+      if (data.data) {
+        // 폼 필드에 데이터 채우기
+        document.getElementById('community-name').value = data.data.name;
+        document.getElementById('description').value = data.data.description;
+
+        // 이미지 미리보기 설정
+        if (data.data.imgUrl) {
+          document.getElementById('icon-preview').src = data.data.imgUrl;
+        }
+
+        // 라디오 버튼 설정
+        const visibilityRadios = document.getElementsByName('visibility');
+        visibilityRadios.forEach(radio => {
+          if ((radio.value === 'public' && data.data.isVisible) ||
+              (radio.value === 'private' && !data.data.isVisible)) {
+            radio.checked = true;
+          }
+        });
+
+        const accessRadios = document.getElementsByName('access');
+        accessRadios.forEach(radio => {
+          if ((radio.value === 'all' && data.data.isPublic) ||
+              (radio.value === 'members' && !data.data.isPublic)) {
+            radio.checked = true;
+          }
+        });
+      }
+    });
+  });
 
   // 이미지 미리보기 기능
-  document.getElementById('community-icon').addEventListener('change', function(e) {
+  document.getElementById('community-icon').addEventListener('change', function (e) {
     const file = e.target.files[0];
     if (file) {
       const reader = new FileReader();
-      reader.onload = function(e) {
+      reader.onload = function (e) {
         document.getElementById('icon-preview').src = e.target.result;
       };
       reader.readAsDataURL(file);
     }
   });
 
-
   // 폼 제출 처리
-  document.getElementById('communityForm').addEventListener('submit', async function(e) {
+  document.getElementById('communityForm').addEventListener('submit', async function (e) {
     e.preventDefault();
 
     const formData = new FormData(this);
     const imageFile = document.getElementById('community-icon').files[0];
-    const token = 'eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuydtOyaqeyekEEiLCJ1aWQiOjJ9.oZzB9H5K81iaQ1qfeA95MfQLMGEpzqxKqWks21qcOR0';
+    // let imgUrl = document.getElementById('icon-preview').getAttribute('data-original-url'); // 기존 이미지 URL 저장
 
     try {
-      let imageUrl = '';
+      let imageUrl = document.getElementById('icon-preview').src;
 
-      // 1. 이미지 업로드 (이미지가 선택된 경우에만)
+      // 새 이미지가 선택된 경우에만 이미지 업로드
       if (imageFile) {
         const imageFormData = new FormData();
         imageFormData.append('image', imageFile);
@@ -259,27 +295,20 @@
         }
 
         const imageResult = await imageResponse.json();
-        if (!imageResult.data) {
-          throw new Error('이미지 URL을 받지 못했습니다.');
-        }
-
-        imageUrl = imageResult.data;
-        console.log('Uploaded image URL:', imageUrl);
+        imageUrl = imageResult.data; // S3에서 반환된 URL
       }
 
-      // 2. 커뮤니티 생성
+      // 커뮤니티 수정
       const communityData = {
         name: formData.get('name'),
         description: formData.get('description'),
-        imgUrl: imageUrl || '', // 이미지 URL이 있으면 사용, 없으면 빈 문자열
+        imgUrl: imageUrl,
         isVisible: formData.get('visibility') === 'public',
         isPublic: formData.get('access') === 'all'
       };
 
-      console.log('Sending community data:', communityData);
-
-      const communityResponse = await fetch('http://localhost:8080/api/communities', {
-        method: 'POST',
+      const response = await fetch(`http://localhost:8080/api/communities/${communityId}`, {
+        method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
           'X-QQ-AUTH-TOKEN': token
@@ -287,22 +316,15 @@
         body: JSON.stringify(communityData)
       });
 
-      if (!communityResponse.ok) {
-        throw new Error('커뮤니티 생성 실패');
+      if (!response.ok) {
+        throw new Error('커뮤니티 수정 실패');
       }
 
-      const result = await communityResponse.json();
-      console.log('Community creation result:', result);
-
-      if (result.data && result.data.id) {
-        window.location.href = `/communities/create-success/${result.data.id}`;
-      } else {
-        throw new Error('커뮤니티 ID를 받지 못했습니다.');
-      }
-
+      const result = await response.json();
+      window.location.href = `/communities/info/${communityId}`;
     } catch (error) {
       console.error('Error:', error);
-      alert(error.message || '커뮤니티 생성 중 오류가 발생했습니다.');
+      alert(error.message || '커뮤니티 수정 중 오류가 발생했습니다.');
     }
   });
 </script>

--- a/src/main/resources/templates/question/question_create.html
+++ b/src/main/resources/templates/question/question_create.html
@@ -53,11 +53,43 @@
       resize: none;
     }
 
+
+    /* 이미지 업로드 버튼 */
+
+    .image-upload-section {
+      margin: 20px 0;
+    }
+
+    .image-preview-container {
+      margin: 10px 0;
+    }
+
+    #image-preview {
+      max-width: 300px;
+      max-height: 200px;
+      margin: 10px 0;
+      border-radius: 5px;
+    }
+
+    .upload-btn {
+      padding: 8px 16px;
+      background-color: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+
+    .upload-btn:hover {
+      background-color: #e0e0e0;
+    }
+
     .file-upload {
       font-size: 14px;
       color: #666;
       margin-bottom: 20px;
     }
+
+
     /* 태그 컨테이너 스타일 */
     .tag-container {
       display: flex;
@@ -67,7 +99,7 @@
     }
 
     .tag-input {
-      width: 150px !important;  /* 기존 100%에서 변경 */
+      width: 150px !important; /* 기존 100%에서 변경 */
       padding: 10px;
       border: 1px solid #ccc;
       border-radius: 5px;
@@ -85,15 +117,6 @@
       font-size: 12px;
       margin-top: 5px;
     }
-
-
-    /*.tag-input {*/
-    /*  width: 100%;*/
-    /*  padding: 10px;*/
-    /*  border: 1px solid #ccc;*/
-    /*  border-radius: 5px;*/
-    /*  margin-bottom: 20px;*/
-    /*}*/
 
     .settings-wrapper {
       border-top: 1px solid #ddd;
@@ -234,8 +257,19 @@
   <label for="question-description">설명<span class="required">*</span></label>
   <textarea id="question-description" placeholder="질문 내용을 입력하세요."></textarea>
 
-  <!-- 파일 첨부 안내 -->
-  <p class="file-upload">사진 첨부 없음</p>
+  <!-- 이미지 업로드 섹션 추가 -->
+  <div class="image-upload-section">
+    <label for="question-image">이미지 첨부</label>
+    <div class="image-preview-container">
+      <img id="image-preview" src="https://via.placeholder.com/200x150" alt="이미지 미리보기"
+           style="display: none;">
+    </div>
+    <input type="file" id="question-image" accept="image/*" style="display: none;">
+    <button type="button" id="upload-button" class="upload-btn">
+      이미지 업로드
+    </button>
+    <p class="file-upload" id="file-name">선택된 파일 없음</p>
+  </div>
 
   <!-- 커뮤니티 선택 섹션 -->
   <label for="community-select">커뮤니티 선택<span class="required">*</span></label>
@@ -250,30 +284,30 @@
   </div>
 
   <!-- 답변 설정 -->
-<!--  <div class="settings-wrapper">-->
-<!--    <h2>답변 설정<span class="required">*</span></h2>-->
-<!--    <div class="settings-group">-->
-<!--      &lt;!&ndash; 공개 여부 &ndash;&gt;-->
-<!--      공개여부-->
-<!--      <div class="divider"></div> &lt;!&ndash; 구분선 &ndash;&gt;-->
+  <!--  <div class="settings-wrapper">-->
+  <!--    <h2>답변 설정<span class="required">*</span></h2>-->
+  <!--    <div class="settings-group">-->
+  <!--      &lt;!&ndash; 공개 여부 &ndash;&gt;-->
+  <!--      공개여부-->
+  <!--      <div class="divider"></div> &lt;!&ndash; 구분선 &ndash;&gt;-->
 
-<!--      <div class="settings">-->
-<!--        <label><input type="radio" name="visibility" value="members" checked> 공개 여부: Members-->
-<!--          Only</label>-->
-<!--        <label><input type="radio" name="visibility" value="all"> 공개 여부: ALL</label>-->
-<!--      </div>-->
+  <!--      <div class="settings">-->
+  <!--        <label><input type="radio" name="visibility" value="members" checked> 공개 여부: Members-->
+  <!--          Only</label>-->
+  <!--        <label><input type="radio" name="visibility" value="all"> 공개 여부: ALL</label>-->
+  <!--      </div>-->
 
-<!--      &lt;!&ndash; 답변/댓글 권한 &ndash;&gt;-->
-<!--      답변/댓글 권한-->
-<!--      <div class="divider"></div> &lt;!&ndash; 구분선 &ndash;&gt;-->
+  <!--      &lt;!&ndash; 답변/댓글 권한 &ndash;&gt;-->
+  <!--      답변/댓글 권한-->
+  <!--      <div class="divider"></div> &lt;!&ndash; 구분선 &ndash;&gt;-->
 
-<!--      <div class="settings">-->
-<!--        <label><input type="radio" name="answer-access" value="members" checked> 답변/댓글 권한: Members-->
-<!--          Only</label>-->
-<!--        <label><input type="radio" name="answer-access" value="all"> 답변/댓글 권한: All</label>-->
-<!--      </div>-->
-<!--    </div>-->
-<!--  </div>-->
+  <!--      <div class="settings">-->
+  <!--        <label><input type="radio" name="answer-access" value="members" checked> 답변/댓글 권한: Members-->
+  <!--          Only</label>-->
+  <!--        <label><input type="radio" name="answer-access" value="all"> 답변/댓글 권한: All</label>-->
+  <!--      </div>-->
+  <!--    </div>-->
+  <!--  </div>-->
 
   <!-- 버튼 섹션 -->
   <div class="buttons">
@@ -298,6 +332,30 @@
   // 페이지 로드 시 커뮤니티 목록을 가져오는 함수
   document.addEventListener('DOMContentLoaded', function () {
     fetchMyCommunities();
+  });
+
+  // 이미지 업로드 관련 코드
+  document.getElementById('upload-button').addEventListener('click', function () {
+    document.getElementById('question-image').click();
+  });
+
+  document.getElementById('question-image').addEventListener('change', function (e) {
+    const file = e.target.files[0];
+    const preview = document.getElementById('image-preview');
+    const fileName = document.getElementById('file-name');
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = function (e) {
+        preview.src = e.target.result;
+        preview.style.display = 'block';
+        fileName.textContent = file.name;
+      }
+      reader.readAsDataURL(file);
+    } else {
+      preview.style.display = 'none';
+      fileName.textContent = '선택된 파일 없음';
+    }
   });
 
   const url = `http://localhost:8080/api/questions`;
@@ -371,7 +429,9 @@
       newInput.type = 'text';
       newInput.className = 'tag-input';
       newInput.placeholder = '#';
-      newInput.onkeyup = function() { validateHashtag(this); };
+      newInput.onkeyup = function () {
+        validateHashtag(this);
+      };
       container.appendChild(newInput);
     }
   }
@@ -394,11 +454,12 @@
   }
 
   // 폼 제출 처리
-  document.querySelector('.submit-btn').addEventListener('click', function() {
+  document.querySelector('.submit-btn').addEventListener('click', async function () {
     const title = document.getElementById('question-title').value;
     const content = document.getElementById('question-description').value.replace(/\n/g, '<br>');
     const commId = document.getElementById('community-select').value;
     const hashtags = getHashtags();
+    const imageFile = document.getElementById('question-image').files[0];
 
     // 필수 필드 검증
     if (!title.trim()) {
@@ -414,40 +475,91 @@
       return;
     }
 
-    const questionData = {
-      title: title,
-      content: content,
-      commId: parseInt(commId),
-      hashtags: hashtags
-    };
+    try {
+      let imageUrl = '';
 
-    // API 요청
-    fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-QQ-AUTH-TOKEN': token
-      },
-      body: JSON.stringify(questionData)
-    })
-    .then(response => response.json())
-    .then(data => {
-      console.log('Received question data:', JSON.stringify(data, null, 2));
+      // 1. 이미지 업로드 (이미지가 선택된 경우에만)
+      if (imageFile) {
+        const imageFormData = new FormData();
+        imageFormData.append('image', imageFile);
+
+        const imageResponse = await fetch('http://localhost:8080/api/images', {
+          method: 'POST',
+          headers: {
+            'X-QQ-AUTH-TOKEN': token
+          },
+          body: imageFormData
+        })
+
+        if (!imageResponse.ok) {
+          throw new Error('이미지 업로드 실패');
+        }
+
+        const imageResult = await imageResponse.json();
+        if (!imageResult.data) {
+          throw new Error('이미지 URL을 받지 못했습니다.');
+        }
+
+        imageUrl = imageResult.data;
+        console.log('Uploaded image URL:', imageUrl);
+      }
+
+      // 2. 질문 생성
+      const questionData = {
+        title: title,
+        content: content,
+        imgUrl: imageUrl || '', // 이미지 URL이 있으면 사용, 없으면 빈 문자열
+        commId: parseInt(commId),
+        hashtags: hashtags
+      };
+
+      // 질문 등록 API 호출
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-QQ-AUTH-TOKEN': token
+        },
+        body: JSON.stringify(questionData)
+      });
+
+      const data = await response.json();
       if (data.data) {
-        // 성공 시 질문 상세 페이지로 이동
         window.location.href = `/questions/info/${data.data.questionId}`;
       } else {
-        alert('질문 등록에 실패했습니다: ' + data.message);
+        throw new Error(data.reason || '질문 등록 실패');
       }
-    })
-    .catch(error => {
+      // API 요청
+      // fetch(url, {
+      //   method: 'POST',
+      //   headers: {
+      //     'Content-Type': 'application/json',
+      //     'X-QQ-AUTH-TOKEN': token
+      //   },
+      //   body: JSON.stringify(questionData)
+      // })
+      // .then(response => response.json())
+      // .then(data => {
+      //   console.log('Received question data:', JSON.stringify(data, null, 2));
+      //   if (data.data) {
+      //     // 성공 시 질문 상세 페이지로 이동
+      //     window.location.href = `/questions/info/${data.data.questionId}`;
+      //   } else {
+      //     alert('질문 등록에 실패했습니다: ' + data.message);
+      //   }
+      // })
+      // .catch(error => {
+      //   console.error('Error:', error);
+      //   alert('질문 등록 중 오류가 발생했습니다.');
+      // });
+    } catch (error) {
       console.error('Error:', error);
-      alert('질문 등록 중 오류가 발생했습니다.');
-    });
+      alert(error.message || '질문 등록 중 오류가 발생했습니다.');
+    }
   });
 
   // 취소 버튼 처리
-  document.querySelector('.cancel-btn').addEventListener('click', function() {
+  document.querySelector('.cancel-btn').addEventListener('click', function () {
     window.history.back();
   });
 </script>

--- a/src/main/resources/templates/question/question_edit.html
+++ b/src/main/resources/templates/question/question_edit.html
@@ -53,11 +53,62 @@
       resize: none;
     }
 
+
+    /* 이미지 업로드 버튼 */
+
+    .image-upload-section {
+      margin: 20px 0;
+    }
+
+    .image-preview-container {
+      margin: 10px 0;
+    }
+
+    #image-preview {
+      max-width: 300px;
+      max-height: 200px;
+      margin: 10px 0;
+      border-radius: 5px;
+    }
+
+    .upload-btn {
+      padding: 8px 16px;
+      background-color: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+
+    .upload-btn:hover {
+      background-color: #e0e0e0;
+    }
+
+    .image-buttons {
+      display: flex;
+      gap: 10px;
+      margin: 10px 0;
+    }
+
+    .remove-btn {
+      padding: 8px 16px;
+      background-color: #ff4444;
+      color: white;
+      border: 1px solid #cc0000;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+
+    .remove-btn:hover {
+      background-color: #cc0000;
+    }
+
     .file-upload {
       font-size: 14px;
       color: #666;
       margin-bottom: 20px;
     }
+
+
     /* 태그 컨테이너 스타일 */
     .tag-container {
       display: flex;
@@ -67,7 +118,7 @@
     }
 
     .tag-input {
-      width: 150px !important;  /* 기존 100%에서 변경 */
+      width: 150px !important; /* 기존 100%에서 변경 */
       padding: 10px;
       border: 1px solid #ccc;
       border-radius: 5px;
@@ -231,8 +282,24 @@
   <label for="question-description">설명<span class="required">*</span></label>
   <textarea id="question-description" placeholder="질문 내용을 입력하세요."></textarea>
 
-  <!-- 파일 첨부 안내 -->
-  <p class="file-upload">사진 첨부 없음</p>
+  <!-- 이미지 업로드 섹션 추가 -->
+  <div class="image-upload-section">
+    <label for="question-image">이미지 첨부</label>
+    <div class="image-preview-container">
+      <img id="image-preview" src="https://via.placeholder.com/200x150" alt="이미지 미리보기"
+           style="display: none;">
+    </div>
+    <div class="image-buttons">
+      <input type="file" id="question-image" accept="image/*" style="display: none;">
+      <button type="button" id="upload-button" class="upload-btn">
+        이미지 업로드
+      </button>
+      <button type="button" id="remove-image" class="remove-btn" style="display: none;">
+        이미지 삭제
+      </button>
+    </div>
+    <p class="file-upload" id="file-name">선택된 파일 없음</p>
+  </div>
 
   <!-- 커뮤니티 선택 섹션 -->
   <label for="community-select">커뮤니티 선택<span class="required">*</span></label>
@@ -261,9 +328,9 @@
   // Thymeleaf 모델 데이터 가져오기
   const communityId = [[${communityId}]];
   const questionId = [[${questionId}]];
-  console.log('Model Data:', { communityId, questionId }); // 데이터 확인용
+  console.log('Model Data:', {communityId, questionId}); // 데이터 확인용
 
-  document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener('DOMContentLoaded', function () {
     if (!questionId) {
       console.error('Question ID is missing');
       return;
@@ -280,14 +347,42 @@
     }
 
     // 수정 버튼 클릭 이벤트
-    document.querySelector('.submit-btn').addEventListener('click', function() {
+    document.querySelector('.submit-btn').addEventListener('click', function () {
       updateQuestion(questionId);
     });
 
     // 취소 버튼 클릭 이벤트
-    document.querySelector('.cancel-btn').addEventListener('click', function() {
+    document.querySelector('.cancel-btn').addEventListener('click', function () {
       window.history.back();
     });
+  });
+
+  // 이미지 업로드 관련 코드
+  document.getElementById('upload-button').addEventListener('click', function () {
+    document.getElementById('question-image').click();
+  });
+
+  // 이미지 업로드 이벤트 수정
+  document.getElementById('question-image').addEventListener('change', function (e) {
+    const file = e.target.files[0];
+    const preview = document.getElementById('image-preview');
+    const fileName = document.getElementById('file-name');
+    const removeButton = document.getElementById('remove-image');
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = function (e) {
+        preview.src = e.target.result;
+        preview.style.display = 'block';
+        fileName.textContent = file.name;
+        removeButton.style.display = 'block';  // 이미지가 있을 때 삭제 버튼 표시
+      }
+      reader.readAsDataURL(file);
+    } else {
+      preview.style.display = 'none';
+      fileName.textContent = '선택된 파일 없음';
+      removeButton.style.display = 'none';  // 이미지가 없을 때 삭제 버튼 숨김
+    }
   });
 
   const url = `http://localhost:8080/api/questions`;
@@ -349,6 +444,16 @@
         document.getElementById('question-title').value = questionData.title;
         document.getElementById('question-description').value = questionData.content;
 
+        // 이미지 처리
+        const preview = document.getElementById('image-preview');
+        const fileName = document.getElementById('file-name');
+        if (questionData.imgUrl) {
+          preview.src = questionData.imgUrl;
+          preview.style.display = 'block';
+          fileName.textContent = '기존 이미지';
+          preview.setAttribute('data-original-url', questionData.imgUrl); // 기존 이미지 URL 저장
+        }
+
         // 커뮤니티 ID 저장
         window.communityId = questionData.commId;
 
@@ -383,7 +488,9 @@
           input.className = 'tag-input';
           // # 제거하고 저장
           input.value = tag.startsWith('#') ? tag.substring(1) : tag;
-          input.onkeyup = function() { validateHashtag(this); };
+          input.onkeyup = function () {
+            validateHashtag(this);
+          };
           container.appendChild(input);
         });
 
@@ -392,7 +499,9 @@
         newInput.type = 'text';
         newInput.className = 'tag-input';
         newInput.placeholder = '#';
-        newInput.onkeyup = function() { validateHashtag(this); };
+        newInput.onkeyup = function () {
+          validateHashtag(this);
+        };
         container.appendChild(newInput);
       }
     })
@@ -400,18 +509,13 @@
   }
 
   // 질문 업데이트
-  function updateQuestion(questionId) {
+  async function updateQuestion(questionId) {
     const title = document.getElementById('question-title').value;
     const content = document.getElementById('question-description').value;
     const commId = document.getElementById('community-select').value;
     const hashtags = getHashtags();
-
-    console.log('Updating question with data:', {
-      title,
-      content,
-      commId,
-      hashtags
-    });
+    const imageFile = document.getElementById('question-image').files[0];
+    const preview = document.getElementById('image-preview');
 
     // 필수 필드 검증
     if (!title.trim()) {
@@ -427,34 +531,91 @@
       return;
     }
 
-    const questionData = {
-      title: title,
-      content: content,
-      commId: parseInt(commId),
-      hashtags: hashtags
-    };
+    try {
+      let imageUrl = preview.getAttribute('data-original-url') || ''; // 기존 이미지 URL
 
-    fetch(url + `/${questionId}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-QQ-AUTH-TOKEN': token
-      },
-      body: JSON.stringify(questionData)
-    })
-    .then(response => response.json())
-    .then(data => {
+      // 새 이미지가 선택된 경우 업로드
+      if (imageFile) {
+        const imageFormData = new FormData();
+        imageFormData.append('image', imageFile);
+
+        const imageResponse = await fetch('http://localhost:8080/api/images', {
+          method: 'POST',
+          headers: {
+            'X-QQ-AUTH-TOKEN': token
+          },
+          body: imageFormData
+        });
+
+        if (!imageResponse.ok) {
+          throw new Error('이미지 업로드 실패');
+        }
+
+        const imageData = await imageResponse.json();
+        if (!imageData.data) {
+          throw new Error('이미지 URL을 받지 못했습니다');
+        }
+
+        imageUrl = imageData.data;
+      }
+
+      const questionData = {
+        title: title,
+        content: content,
+        commId: parseInt(commId),
+        hashtags: hashtags,
+        imgUrl: imageUrl
+      };
+
+      const response = await fetch(url + `/${questionId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-QQ-AUTH-TOKEN': token
+        },
+        body: JSON.stringify(questionData)
+      });
+
+      const data = await response.json();
       if (data.data) {
         alert('질문이 수정되었습니다.');
         window.location.href = `/questions/info/${questionId}`;
       } else {
-        alert('질문 수정에 실패했습니다: ' + data.message);
+        throw new Error(data.message || '질문 수정 실패');
       }
-    })
-    .catch(error => {
+    } catch (error) {
       console.error('Error:', error);
-      alert('질문 수정 중 오류가 발생했습니다.');
-    });
+      alert(error.message || '질문 수정 중 오류가 발생했습니다.');
+    }
+
+    // const questionData = {
+    //   title: title,
+    //   content: content,
+    //   commId: parseInt(commId),
+    //   hashtags: hashtags
+    // };
+    //
+    // fetch(url + `/${questionId}`, {
+    //   method: 'PUT',
+    //   headers: {
+    //     'Content-Type': 'application/json',
+    //     'X-QQ-AUTH-TOKEN': token
+    //   },
+    //   body: JSON.stringify(questionData)
+    // })
+    // .then(response => response.json())
+    // .then(data => {
+    //   if (data.data) {
+    //     alert('질문이 수정되었습니다.');
+    //     window.location.href = `/questions/info/${questionId}`;
+    //   } else {
+    //     alert('질문 수정에 실패했습니다: ' + data.message);
+    //   }
+    // })
+    // .catch(error => {
+    //   console.error('Error:', error);
+    //   alert('질문 수정 중 오류가 발생했습니다.');
+    // });
   }
 
   /* 해시태그 */
@@ -478,7 +639,9 @@
       newInput.type = 'text';
       newInput.className = 'tag-input';
       newInput.placeholder = '#';
-      newInput.onkeyup = function() { validateHashtag(this); };
+      newInput.onkeyup = function () {
+        validateHashtag(this);
+      };
       container.appendChild(newInput);
     }
   }
@@ -497,6 +660,25 @@
     console.log('Collected hashtags:', hashtags); // 디버깅용
     return hashtags;
   }
+
+  // 이미지 삭제 버튼 이벤트
+  document.getElementById('remove-image').addEventListener('click', function () {
+    const preview = document.getElementById('image-preview');
+    const fileName = document.getElementById('file-name');
+    const imageInput = document.getElementById('question-image');
+
+    // 이미지 미리보기 초기화
+    preview.src = 'https://via.placeholder.com/200x150';
+    preview.style.display = 'none';
+    preview.removeAttribute('data-original-url');
+
+    // 파일 입력 초기화
+    imageInput.value = '';
+    fileName.textContent = '선택된 파일 없음';
+
+    // 삭제 버튼 숨기기
+    this.style.display = 'none';
+  });
 
 </script>
 </body>

--- a/src/main/resources/templates/question/question_info.html
+++ b/src/main/resources/templates/question/question_info.html
@@ -609,7 +609,7 @@
 
     <!-- 오른쪽 섹션 (커뮤니티 정보) -->
     <div id="community-info">
-      <img src="https://via.placeholder.com/20" alt="커뮤니티 아이콘">
+<!--      <img src="https://via.placeholder.com/20" alt="커뮤니티 아이콘">-->
       <span id="community-name">커뮤니티 이름</span>
     </div>
   </div>

--- a/src/main/resources/templates/question/question_info.html
+++ b/src/main/resources/templates/question/question_info.html
@@ -828,6 +828,28 @@
     contentElement.style.whiteSpace = 'pre-wrap';
     contentElement.textContent = questionInfo.content;
 
+    // 이미지 표시 추가
+    const existingImage = document.querySelector('.question-image');
+    if (existingImage) {
+      existingImage.remove();
+    }
+
+    if (questionInfo.imgUrl) {
+      const imageDiv = document.createElement('div');
+      imageDiv.className = 'question-image';
+      imageDiv.innerHTML = `
+            <img src="${questionInfo.imgUrl}" alt="질문 이미지" style="
+                width: 600px;
+                max-width: 100%;
+                height: auto;
+                margin: 20px 0;
+                border-radius: 5px;
+                box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+            ">
+        `;
+      contentElement.parentNode.insertBefore(imageDiv, document.getElementById('question-tags'));
+    }
+
     // 작성 시간 업데이트
     const createdAtElement = document.querySelector('.question-header-left div:last-child');
     createdAtElement.innerHTML = `${formatDate(


### PR DESCRIPTION
## 🚀 연관된 이슈

- resolve: #62 

## ✨ 작업 내용

### 커뮤니티

- 커뮤니티 프로필 이미지 업로드

  <img width="600" alt="image" src="https://github.com/user-attachments/assets/28f3be5e-0291-4800-aa41-6084ce407c08">

- 커뮤니티 정보 수정 버튼 추가
- 커뮤니티 프로필 이미지 조회

  <img width="282" alt="image" src="https://github.com/user-attachments/assets/de722bca-929c-4a05-91c2-c2b223d00e55">

### 질문

- 질문 등록 시 이미지 업로드

  <img width="600" alt="image" src="https://github.com/user-attachments/assets/7e941729-f7b4-4e96-a736-21bd09e0add7">

- 질문 조회 시 이미지 조회

  <img width="600" alt="image" src="https://github.com/user-attachments/assets/155383dc-0206-4856-846f-6353af28d6fd">


## 💬 리뷰 요구사항(선택)

- application.yml 파일을 비롯하여 전부 추가되었습니다. 충돌 가능성 한 번만 확인해주시고, 이후 merge 한 후에는 따로 드리는 환경 변수를 dev 프로필에 추가해주세요.
- 회원가입 및 로그인 이후 프론트에서 게시글 또는 댓글의 유저에 프로필 조회 기능을 추가해주세요 - 우선순위는 높지 않습니다!
- 이미지 업로드의 경우 S3Controller 를 통해 따로 등록 후, 반환된 imgUrl 을 다시 커뮤니티 등의 생성 데이터에 추가하여 진행하였습니다. 자세한 건 추후 연구일지를 확인해주세요!