### PR TITLE
feat: AI 답변 선택화에 따른 비동기 처리 및 처리율 제한 횟수 조회

### DIFF
--- a/src/main/java/com/hanshin/supernova/ai_comment/application/AiAnswerService.java
+++ b/src/main/java/com/hanshin/supernova/ai_comment/application/AiAnswerService.java
@@ -18,7 +18,7 @@ public class AiAnswerService {
 
     private final ChatGptAPIManager chatGptAPIManager;
 
-    @RateLimit(key = "'createAIAnswerTest2:user' + #user.id", limit = 5, period = 24 * 60 * 60)
+    @RateLimit(key = "'createAIAnswerTest:user' + #user.id", limit = 5, period = 24 * 60 * 60)
     public AiAnswerResponse generateAiAnswer(AuthUser user, String title, String content) {
         try {
             return chatGptAPIManager.generateAiAnswer(title, content);
@@ -32,10 +32,12 @@ public class AiAnswerService {
             } else {
                 throw new GptInvalidException(ErrorType.GPT_REQUEST_FAILED);
             }
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
         }
     }
 
-    @RateLimit(key = "'createAIAnswerTest1:user' + #user.id", limit = 5, period = 24 * 60 * 60)
+    @RateLimit(key = "'createAIAnswerTest:user' + #user.id", limit = 5, period = 24 * 60 * 60)
     public AiAnswerResponse regenerateAiAnswer(AuthUser user, String title, String content, String preAnswer) {
         try {
             return chatGptAPIManager.regenerateAiAnswer(title, content, preAnswer);

--- a/src/main/java/com/hanshin/supernova/answer/application/AiCommentService.java
+++ b/src/main/java/com/hanshin/supernova/answer/application/AiCommentService.java
@@ -39,7 +39,7 @@ public class AiCommentService extends AbstractValidateService {
     public AiCommentResponse getAiComment(Long questionId) {
         getQuestionOrThrowIfNotExist(questionId);
 
-        AiComment findAiComment = aiCommentRepository.findByQuestionId(questionId);
+        AiComment findAiComment = aiCommentRepository.findByQuestionId(questionId).orElse(null);
         if (findAiComment == null) {
             return null;
         }
@@ -52,7 +52,7 @@ public class AiCommentService extends AbstractValidateService {
     public AiCommentResponse updateAiComment(AuthUser user, AiCommentRequest request) {
         Question findQuestion = getQuestionOrThrowIfNotExist(request.getQuestionId());
 
-        AiComment findAiComment = aiCommentRepository.findByQuestionId(request.getQuestionId());
+        AiComment findAiComment = aiCommentRepository.findByQuestionId(request.getQuestionId()).orElse(null);
 
         verifySameUser(user, findQuestion.getQuestionerId());
 

--- a/src/main/java/com/hanshin/supernova/answer/infrastructure/AiCommentRepository.java
+++ b/src/main/java/com/hanshin/supernova/answer/infrastructure/AiCommentRepository.java
@@ -1,9 +1,10 @@
 package com.hanshin.supernova.answer.infrastructure;
 
 import com.hanshin.supernova.answer.domain.AiComment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AiCommentRepository extends JpaRepository<AiComment, Long> {
 
-    AiComment findByQuestionId(Long questionId);
+    Optional<AiComment> findByQuestionId(Long questionId);
 }

--- a/src/main/java/com/hanshin/supernova/question/dto/request/QuestionRequest.java
+++ b/src/main/java/com/hanshin/supernova/question/dto/request/QuestionRequest.java
@@ -1,5 +1,6 @@
 package com.hanshin.supernova.question.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -24,4 +25,7 @@ public class QuestionRequest {
 
     @Size(max = 10, message = "해시태그는 최대 10개까지 등록이 가능합니다.")
     private List<String> hashtags;
+
+    @JsonProperty("isAiAnswerRequested")
+    private boolean isAiAnswerRequested;
 }

--- a/src/main/java/com/hanshin/supernova/rate_limiter/aop/RateLimitingAspect.java
+++ b/src/main/java/com/hanshin/supernova/rate_limiter/aop/RateLimitingAspect.java
@@ -39,19 +39,7 @@ public class RateLimitingAspect {
                 rateLimit.period());
 
         if (remainingTokens >= 0) {
-            Object result = joinPoint.proceed();
-            log.debug("Method execution result: {}", result);
-
-            // 현재 실행 컨텍스트에서 HttpServletResponse 얻기
-            HttpServletResponse response = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getResponse();
-            if (response != null) {
-                response.setHeader("X-RateLimit-Remaining", String.valueOf(remainingTokens));
-                log.debug("Added X-RateLimit-Remaining header: {}", remainingTokens);
-            } else {
-                log.warn("Unable to set X-RateLimit-Remaining header: HttpServletResponse is null");
-            }
-
-            return result;
+            return joinPoint.proceed();
         } else {
             throw rateLimit.exceptionClass().getDeclaredConstructor(String.class)
                     .newInstance("Rate limit exceeded for key: " + key);

--- a/src/main/java/com/hanshin/supernova/rate_limiter/application/APIRateLimiter.java
+++ b/src/main/java/com/hanshin/supernova/rate_limiter/application/APIRateLimiter.java
@@ -62,4 +62,15 @@ public class APIRateLimiter {
 
         return remainingTokens;
     }
+
+    /**
+     * 토큰을 소비하지 않고 남은 토큰 수만 확인하는 메서드
+     */
+    public long getRemainingTokens(String key, int limit, int period) {
+        Bucket bucket = proxyManager.builder().build(key, BucketConfiguration.builder()
+                .addLimit(Bandwidth.simple(limit, Duration.ofSeconds(period)))
+                .build());
+
+        return bucket.getAvailableTokens();
+    }
 }

--- a/src/main/java/com/hanshin/supernova/rate_limiter/dto/RateLimitStatusResponse.java
+++ b/src/main/java/com/hanshin/supernova/rate_limiter/dto/RateLimitStatusResponse.java
@@ -1,0 +1,11 @@
+package com.hanshin.supernova.rate_limiter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RateLimitStatusResponse {
+
+    private long remainingGenerateCount;
+}

--- a/src/main/java/com/hanshin/supernova/rate_limiter/presentation/RateLimitController.java
+++ b/src/main/java/com/hanshin/supernova/rate_limiter/presentation/RateLimitController.java
@@ -1,0 +1,41 @@
+package com.hanshin.supernova.rate_limiter.presentation;
+
+import com.hanshin.supernova.auth.model.AuthUser;
+import com.hanshin.supernova.rate_limiter.application.APIRateLimiter;
+import com.hanshin.supernova.rate_limiter.dto.RateLimitStatusResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 처리율 제한기 남은 횟수 조회 API
+ */
+@CrossOrigin
+@RestController
+@RequestMapping(path = "/api/rate-limit")
+@RequiredArgsConstructor
+public class RateLimitController {
+
+    private final APIRateLimiter apiRateLimiter;
+
+    /**
+     * AI 답변 생성 남은 횟수 조회
+     */
+    @GetMapping("/ai-answers")
+    public ResponseEntity<RateLimitStatusResponse> getRateLimitStatus(
+            AuthUser user
+    ) {
+        long remainingGenerate = apiRateLimiter.getRemainingTokens(
+                "createAIAnswerTest:user" + user.getId(),
+                5,
+                24 * 60 * 60
+        );
+
+        return ResponseEntity.ok(
+                new RateLimitStatusResponse(remainingGenerate));
+    }
+
+}

--- a/src/main/resources/templates/question/question_create.html
+++ b/src/main/resources/templates/question/question_create.html
@@ -211,6 +211,10 @@
       border-color: #007bff;
     }
 
+    .ai-answer-request {
+      padding-top: 10px;
+    }
+
     /* 무엇이든 물어보세요 버튼 */
     .chat-widget {
       position: fixed;
@@ -283,6 +287,17 @@
     <input type="text" class="tag-input" placeholder="#" onkeyup="validateHashtag(this)">
   </div>
 
+  <!-- AI 답변 선택 및 남은 요청 가능 횟수 조회 -->
+  <div style="display: flex; align-items: center; margin: 20px 0;">
+    <div style="display: flex; align-items: center;">
+      <input type="checkbox" id="ai-answer-checkbox" style="margin-right: 8px;">
+      <label for="ai-answer-checkbox" class="ai-answer-request">AI 답변 요청하기</label>
+    </div>
+    <div id="remaining-count" style="margin-left: 30px; color: #666;">
+      남은 요청 가능 횟수: <span id="remaining-count-value">-</span>회
+    </div>
+  </div>
+
   <!-- 답변 설정 -->
   <!--  <div class="settings-wrapper">-->
   <!--    <h2>답변 설정<span class="required">*</span></h2>-->
@@ -335,6 +350,7 @@
   // 페이지 로드 시 커뮤니티 목록을 가져오는 함수
   document.addEventListener('DOMContentLoaded', function () {
     fetchMyCommunities();
+    fetchRemainingCount(); // 남은 횟수 조회 추가
   });
 
   // 이미지 업로드 관련 코드
@@ -411,6 +427,36 @@
     if (communityId) {
       select.value = communityId;
     }
+  }
+
+  // 남은 횟수 조회 함수
+  function fetchRemainingCount() {
+    fetch(baseURL + '/api/rate-limit/ai-answers', {
+      headers: {
+        'X-QQ-AUTH-TOKEN': token
+      }
+    })
+    .then(response => response.json())
+    .then(data => {
+      const remainingCountElement = document.getElementById('remaining-count-value');
+      remainingCountElement.textContent = data.remainingGenerateCount;
+
+      // 체크박스 상태 제어
+      const checkbox = document.getElementById('ai-answer-checkbox');
+      if (data.remainingGenerateCount <= 0) {
+        checkbox.disabled = true;  // 체크박스 비활성화
+        checkbox.checked = false;  // 체크 해제
+        checkbox.title = "남은 AI 답변 요청 횟수가 없습니다";  // 마우스 오버 시 툴팁
+      } else {
+        checkbox.disabled = false;
+        checkbox.title = "";
+      }
+    })
+    .catch(error => {
+      console.error('Error fetching remaining count:', error);
+      const remainingCountElement = document.getElementById('remaining-count-value');
+      remainingCountElement.textContent = '-';
+    });
   }
 
   /* 해시태그 */
@@ -515,7 +561,8 @@
         content: content,
         imgUrl: imageUrl || '', // 이미지 URL이 있으면 사용, 없으면 빈 문자열
         commId: parseInt(commId),
-        hashtags: hashtags
+        hashtags: hashtags,
+        isAiAnswerRequested: document.getElementById('ai-answer-checkbox').checked
       };
 
       // 질문 등록 API 호출

--- a/src/main/resources/templates/question/question_edit.html
+++ b/src/main/resources/templates/question/question_edit.html
@@ -239,6 +239,10 @@
       border-color: #007bff;
     }
 
+    .ai-answer-request {
+      padding-top: 10px;
+    }
+
     /* 무엇이든 물어보세요 버튼 */
     .chat-widget {
       position: fixed;
@@ -312,6 +316,17 @@
     <!-- 태그 입력 필드는 JavaScript로 동적 생성 -->
   </div>
 
+  <!-- AI 답변 선택 및 남은 요청 가능 횟수 조회 -->
+  <div style="display: flex; align-items: center; margin: 20px 0;">
+    <div style="display: flex; align-items: center;">
+      <input type="checkbox" id="ai-answer-checkbox" style="margin-right: 8px;">
+      <label for="ai-answer-checkbox" class="ai-answer-request">AI 답변 요청하기</label>
+    </div>
+    <div id="remaining-count" style="margin-left: 30px; color: #666;">
+      남은 요청 가능 횟수: <span id="remaining-count-value">-</span>회
+    </div>
+  </div>
+
   <div class="buttons">
     <button class="cancel-btn">취소</button>
     <button class="submit-btn">수정하기</button>
@@ -348,6 +363,8 @@
       console.log('No community ID from model, fetching default communities');
       fetchMyCommunities();
     }
+
+    fetchRemainingCount(); // 남은 횟수 조회 추가
 
     // 수정 버튼 클릭 이벤트
     document.querySelector('.submit-btn').addEventListener('click', function () {
@@ -434,6 +451,36 @@
     });
   }
 
+  // 남은 횟수 조회 함수
+  function fetchRemainingCount() {
+    fetch(baseURL + '/api/rate-limit/ai-answers', {
+      headers: {
+        'X-QQ-AUTH-TOKEN': token
+      }
+    })
+    .then(response => response.json())
+    .then(data => {
+      const remainingCountElement = document.getElementById('remaining-count-value');
+      remainingCountElement.textContent = data.remainingGenerateCount;
+
+      // 체크박스 상태 제어
+      const checkbox = document.getElementById('ai-answer-checkbox');
+      if (data.remainingGenerateCount <= 0) {
+        checkbox.disabled = true;  // 체크박스 비활성화
+        checkbox.checked = false;  // 체크 해제
+        checkbox.title = "남은 AI 답변 요청 횟수가 없습니다";  // 마우스 오버 시 툴팁
+      } else {
+        checkbox.disabled = false;
+        checkbox.title = "";
+      }
+    })
+    .catch(error => {
+      console.error('Error fetching remaining count:', error);
+      const remainingCountElement = document.getElementById('remaining-count-value');
+      remainingCountElement.textContent = '-';
+    });
+  }
+
   // 기존 질문 데이터 로드
   function loadQuestionData(questionId) {
     fetch(url + `/${questionId}`, {
@@ -450,6 +497,7 @@
         const questionData = data.data;
         document.getElementById('question-title').value = questionData.title;
         document.getElementById('question-description').value = questionData.content;
+        document.getElementById('ai-answer-checkbox').checked = questionData.isAiAnswerRequested;
 
         // 이미지 처리
         const preview = document.getElementById('image-preview');
@@ -523,6 +571,7 @@
     const hashtags = getHashtags();
     const imageFile = document.getElementById('question-image').files[0];
     const preview = document.getElementById('image-preview');
+    const isAiAnswerRequested = document.getElementById('ai-answer-checkbox').checked;
 
     // 필수 필드 검증
     if (!title.trim()) {
@@ -571,7 +620,8 @@
         content: content,
         commId: parseInt(commId),
         hashtags: hashtags,
-        imgUrl: imageUrl
+        imgUrl: imageUrl,
+        isAiAnswerRequested: isAiAnswerRequested
       };
 
       const response = await fetch(url + `/${questionId}`, {

--- a/src/main/resources/templates/question/question_info.html
+++ b/src/main/resources/templates/question/question_info.html
@@ -260,6 +260,13 @@
       margin-right: 20px;
     }
 
+    .regeneration-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+    }
+
     #regenerationBtn {
       min-width: 120px;
       width: 120px;
@@ -270,6 +277,22 @@
       border-radius: 5px;
       cursor: pointer;
     }
+
+    .remaining-count {
+      font-size: 12px;
+      color: #666;
+    }
+
+    /*#regenerationBtn {*/
+    /*  min-width: 120px;*/
+    /*  width: 120px;*/
+    /*  padding: 10px 20px;*/
+    /*  background-color: #007bff;*/
+    /*  color: white;*/
+    /*  border: none;*/
+    /*  border-radius: 5px;*/
+    /*  cursor: pointer;*/
+    /*}*/
 
     /* 답변 확인하기 */
 
@@ -641,9 +664,17 @@
   </div>
 
   <!-- AI 답변 섹션 -->
+<!--  <div class="ai-answer-container">-->
+<!--    <div id="ai-answer-section"></div>-->
+<!--    <button id="regenerationBtn">답변 새로 받기</button>-->
+<!--  </div>-->
+
   <div class="ai-answer-container">
     <div id="ai-answer-section"></div>
-    <button id="regenerationBtn">답변 새로 받기</button>
+    <div class="regeneration-container">
+      <button id="regenerationBtn">답변 새로 받기</button>
+      <span id="remaining-count" class="remaining-count">남은 횟수: -회</span>
+    </div>
   </div>
 
 
@@ -696,6 +727,7 @@
 <script type="module">
   import CONFIG from '/static/js/config.js';
   let questionId = null;
+
   document.addEventListener('DOMContentLoaded', function () {
     questionId = [[${questionId}]];
     console.log('Initializing with question ID:', questionId);
@@ -733,8 +765,28 @@
   // const url = `http://localhost:8080/api/questions`;
   // const token = 'eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuydtOyaqeyekEEiLCJ1aWQiOjJ9.oZzB9H5K81iaQ1qfeA95MfQLMGEpzqxKqWks21qcOR0';
   const url = CONFIG.API.BASE_URL + CONFIG.API.ENDPOINTS.QUESTIONS;
-  // const baseURL = CONFIG.API.BASE_URL;
+  const baseURL = CONFIG.API.BASE_URL;
   const token = CONFIG.AUTH.DEFAULT_TOKEN;
+
+  // 페이지 로드 시와 재생성 버튼 클릭 시 남은 횟수를 조회하는 함수
+  async function fetchRemainingCount() {
+    try {
+      const response = await fetch(baseURL + '/api/rate-limit/ai-answers', {
+        headers: {
+          'X-QQ-AUTH-TOKEN': token
+        }
+      });
+      const data = await response.json();
+
+      // 남은 횟수 업데이트
+      const remainingCountElement = document.getElementById('remaining-count');
+      remainingCountElement.textContent = `남은 횟수: ${data.remainingGenerateCount}회`;
+    } catch (error) {
+      console.error('Error fetching remaining count:', error);
+      const remainingCountElement = document.getElementById('remaining-count');
+      remainingCountElement.textContent = '남은 횟수: -회';
+    }
+  }
 
   // 해시태그 정보
   function fetchHashtagInfo(questionId) {
@@ -1055,6 +1107,26 @@
   }
 
   // AI 답변
+  // function fetchAiComment(questionId) {
+  //   fetch(url + `/${questionId}/ai-answers`, {
+  //     method: 'GET',
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //       'X-QQ-AUTH-TOKEN': token
+  //     }
+  //   })
+  //   .then(response => response.json())
+  //   .then(data => {
+  //     console.log('Received AI answers data:', JSON.stringify(data, null, 2)); // 데이터 구조를 자세히 로그에 출력
+  //
+  //     if (data.data) {
+  //       displayAiComment(data.data);
+  //     } else {
+  //       console.error('Error loading answers:', data);
+  //     }
+  //   })
+  //   .catch(error => console.error('Error:', error));
+  // }
   function fetchAiComment(questionId) {
     fetch(url + `/${questionId}/ai-answers`, {
       method: 'GET',
@@ -1065,16 +1137,31 @@
     })
     .then(response => response.json())
     .then(data => {
-      console.log('Received AI answers data:', JSON.stringify(data, null, 2)); // 데이터 구조를 자세히 로그에 출력
+      console.log('Received AI answers data:', JSON.stringify(data, null, 2));
+
+      // AI 답변 컨테이너 가져오기
+      const aiAnswerContainer = document.querySelector('.ai-answer-container');
 
       if (data.data) {
+        // AI 답변이 있는 경우
+        aiAnswerContainer.style.display = 'flex';  // 컨테이너 보이기
         displayAiComment(data.data);
+        // 남은 횟수 조회
+        fetchRemainingCount();
       } else {
-        console.error('Error loading answers:', data);
+        // AI 답변이 없는 경우
+        aiAnswerContainer.style.display = 'none';  // 컨테이너 숨기기
+        console.log('No AI answer available');
       }
     })
-    .catch(error => console.error('Error:', error));
+    .catch(error => {
+      console.error('Error:', error);
+      // 에러 발생 시 컨테이너 숨기기
+      const aiAnswerContainer = document.querySelector('.ai-answer-container');
+      aiAnswerContainer.style.display = 'none';
+    });
   }
+
 
   function displayAiComment(aiAnswer) {
     const container = document.getElementById('ai-answer-section');
@@ -1093,40 +1180,41 @@
     const regenerationBtn = document.getElementById('regenerationBtn');
     const originalText = regenerationBtn.textContent;
 
-    regenerationBtn.addEventListener('click', () => {
-      // 버튼 텍스트 변경 및 비활성화
+    // 페이지 로드 시 남은 횟수 조회
+    fetchRemainingCount();
+
+    regenerationBtn.addEventListener('click', async () => {
       regenerationBtn.textContent = '...';
       regenerationBtn.disabled = true;
 
-      fetch(url + `/${questionId}/ai-answers`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-QQ-AUTH-TOKEN': token
-        }
-      })
-      .then(response => response.json())
-      .then(data => {
-        console.log('Received AI answers data:', JSON.stringify(data, null, 2)); // 데이터 구조를 자세히 로그에 출력
+      try {
+        const response = await fetch(url + `/${questionId}/ai-answers`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-QQ-AUTH-TOKEN': token
+          }
+        });
+        const data = await response.json();
 
         if (data.data) {
           displayAiComment(data.data);
+          // 답변 생성 후 남은 횟수 다시 조회
+          await fetchRemainingCount();
         } else {
-          console.error('Error re-generating ai answers:', data);
           let errorMessage = 'AI 답변을 생성 중 오류가 발생했습니다.';
           if (data.reason) {
             errorMessage += `\n이유: ${data.reason}`;
           }
           alert(errorMessage);
         }
-      })
-      .catch(error => console.error('Error:', error))
-      .finally(() => {
-        // 요청 완료 후 버튼 텍스트 복원 및 활성화
+      } catch (error) {
+        console.error('Error:', error);
+      } finally {
         regenerationBtn.textContent = originalText;
         regenerationBtn.disabled = false;
-      });
-    })
+      }
+    });
   }
 
   function fetchComments(questionId) {


### PR DESCRIPTION

## 🚀 연관된 이슈

- #55 

## ✨ 작업 내용

- AI 답변 요청을 선택할 수 있는 체크박스 추가
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/4f19b95c-4da8-4816-80d9-c5202fa800c1">

- 남은 요청 가능 횟수를 게시글 생성 및 수정, 댓글 재요청 버튼에 추가

- 게시글에 대해 AI 답변 요청 비동기 처리
  
- 알림 제목에 게시글 제목 일부 추가
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/6b9a3bd3-0616-4e83-be77-c2e2bb4d1212">


## 💬 리뷰 요구사항(선택)

- 현재 `X-QQ-AUTH-TOKEN` 으로 되어 있는데, 회원 관련 PR이 develop 에 병합되면 `X-QQ-ACCESS-TOKEN`으로 수정할 예정입니다.