### PR TITLE
feat: 일반 게시판 분리 및 메인 페이지 최신 질문 목록 구현

### DIFF
--- a/src/main/java/com/hanshin/supernova/question/application/QuestionListService.java
+++ b/src/main/java/com/hanshin/supernova/question/application/QuestionListService.java
@@ -20,6 +20,39 @@ public class QuestionListService extends AbstractValidateService {
 
     private final QuestionRepository questionRepository;
 
+
+    public List<QuestionInfoResponse> getNLatestQuestionsByDesc(int limit) {
+
+        Pageable pageable = PageRequest.of(0, limit);
+        List<Question> findAllQuestions = questionRepository.findNLatestQuestionsByCreatedAtDesc(limit, pageable);
+
+        return getQuestionInfoResponses(findAllQuestions);
+    }
+
+    public Page<QuestionInfoResponse> getAllLatestQuestionsByDesc(Pageable pageable) {
+
+        Page<Question> findAllQuestions = questionRepository.findAllOrderByCreatedAtDesc(pageable);
+
+        return findAllQuestions.map(this::convertToQuestionInfoResponse);
+    }
+
+    public List<QuestionInfoResponse> getNLatestQuestionsFromGeneralCommunityByDesc(int limit) {
+
+        Pageable pageable = PageRequest.of(0, limit);
+        List<Question> findAllQuestions = questionRepository.findNLatestQuestionsFromGeneralCommunityByCreatedAtDesc(limit, pageable);
+
+        return getQuestionInfoResponses(findAllQuestions);
+    }
+
+    public Page<QuestionInfoResponse> getAllLatestQuestionsFromGeneralCommunityByDesc(Pageable pageable) {
+
+        Page<Question> findAllQuestions = questionRepository.findAllFromGeneralCommunityOrderByCreatedAtDesc(pageable);
+
+        return findAllQuestions.map(this::convertToQuestionInfoResponse);
+    }
+
+
+
     /**
      * 답변이 채택되지 않은 질문 목록 - 최신 순
      */

--- a/src/main/java/com/hanshin/supernova/question/infrastructure/QuestionRepository.java
+++ b/src/main/java/com/hanshin/supernova/question/infrastructure/QuestionRepository.java
@@ -2,7 +2,6 @@ package com.hanshin.supernova.question.infrastructure;
 
 import com.hanshin.supernova.question.domain.Question;
 import java.time.LocalDate;
-import java.util.Collection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import java.util.List;
@@ -15,6 +14,28 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 @Transactional(readOnly = true)
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    @Query("SELECT q FROM Question q " +
+            "WHERE q.commId > 1" +
+            "ORDER BY q.createdAt DESC " +
+            "LIMIT :N")
+    List<Question> findNLatestQuestionsByCreatedAtDesc(@Param("N") Integer limitNumber, Pageable pageable);
+
+    @Query("SELECT q FROM Question q " +
+            "WHERE q.commId > 1" +
+            "ORDER BY q.createdAt DESC")
+    Page<Question> findAllOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("SELECT q FROM Question q " +
+            "WHERE q.commId = 1" +
+            "ORDER BY q.createdAt DESC " +
+            "LIMIT :N")
+    List<Question> findNLatestQuestionsFromGeneralCommunityByCreatedAtDesc(@Param("N") Integer limitNumber, Pageable pageable);
+
+    @Query("SELECT q FROM Question q " +
+            "WHERE q.commId = 1" +
+            "ORDER BY q.createdAt DESC")
+    Page<Question> findAllFromGeneralCommunityOrderByCreatedAtDesc(Pageable pageable);
 
     @Query("SELECT q FROM Question q WHERE q.commId=:commId AND q.isResolved=:isResolved ORDER BY q.createdAt ASC")
     Page<Question> findAllByCommIdAndIsResolvedOrderByCreatedAtAsc(@Param("commId") Long c_id, @Param("isResolved") boolean isResolved, Pageable pageable);

--- a/src/main/java/com/hanshin/supernova/question/presentation/QuestionListController.java
+++ b/src/main/java/com/hanshin/supernova/question/presentation/QuestionListController.java
@@ -19,14 +19,53 @@ import org.springframework.web.bind.annotation.RestController;
 
 @CrossOrigin(origins = CROSS_ORIGIN_ADDRESS)
 @RestController
-@RequestMapping(path = "/api/communities/{c_id}")
+@RequestMapping(path = "/api/communities")
 @RequiredArgsConstructor
 public class QuestionListController {
 
     private final QuestionListService questionListService;
 
-    @GetMapping(path = "/all-latest-questions")
-    public ResponseEntity<?> allLatestQuestions(
+    /**
+     * 일반 게시판을 제외하고 전체 커뮤니티 최신 질문 N개 목록
+     */
+    @GetMapping(path = "/N-latest-questions")
+    public ResponseEntity<?> nLatestQuestions() {
+        List<QuestionInfoResponse> responses = questionListService.getNLatestQuestionsByDesc(5);
+        return ResponseDto.ok(responses);
+    }
+
+    /**
+     * 일반 게시판을 제외하고 전체 커뮤니티 최신 질문 전체 목록
+     */
+//    @GetMapping(path = "/all-latest-questions")
+//    public ResponseEntity<?> allLatestQuestions(
+//            @PageableDefault(size = 7) Pageable pageable) {
+//        Page<QuestionInfoResponse> responses = questionListService.getAllLatestQuestionsByDesc(pageable);
+//        return ResponseDto.ok(responses);
+//    }
+
+    /**
+     * 일반 게시판 최신 질문 4개 목록
+     */
+    @GetMapping(path = "/N-latest-questions-from-general")
+    public ResponseEntity<?> nLatestQuestionsFromGeneralCommunity() {
+        List<QuestionInfoResponse> responses = questionListService.getNLatestQuestionsFromGeneralCommunityByDesc(5);
+        return ResponseDto.ok(responses);
+    }
+
+    /**
+     * 일반 게시판 최신 질문 전체 목록
+     */
+//    @GetMapping(path = "/all-latest-questions-from-general")
+//    public ResponseEntity<?> allLatestQuestionsFromGeneralCommunity(
+//            @PageableDefault(size = 7) Pageable pageable) {
+//        Page<QuestionInfoResponse> responses = questionListService.getAllLatestQuestionsFromGeneralCommunityByDesc(pageable);
+//        return ResponseDto.ok(responses);
+//    }
+
+
+    @GetMapping(path = "/{c_id}/all-latest-questions")
+    public ResponseEntity<?> allLatestQuestionsByCommunity(
             @PathVariable("c_id") Long cId,
             @PageableDefault(size = 7) Pageable pageable
     ) {
@@ -35,7 +74,7 @@ public class QuestionListController {
         return ResponseDto.ok(response);
     }
 
-    @GetMapping(path = "/all-old-questions")
+    @GetMapping(path = "/{c_id}/all-old-questions")
     public ResponseEntity<?> allOldQuestions(
             @PathVariable("c_id") Long cId,
             @PageableDefault(size = 7) Pageable pageable
@@ -45,7 +84,7 @@ public class QuestionListController {
         return ResponseDto.ok(response);
     }
 
-    @GetMapping(path = "/unanswered-latest-questions")
+    @GetMapping(path = "/{c_id}/unanswered-latest-questions")
     public ResponseEntity<?> unansweredLatestQuestions(
             @PathVariable("c_id") Long cId,
             @PageableDefault(size = 7) Pageable pageable
@@ -55,7 +94,7 @@ public class QuestionListController {
         return ResponseDto.ok(responses);
     }
 
-    @GetMapping(path = "/unanswered-old-questions")
+    @GetMapping(path = "/{c_id}/unanswered-old-questions")
     public ResponseEntity<?> unansweredOldQuestions(
             @PathVariable("c_id") Long cId,
             @PageableDefault(size = 7) Pageable pageable
@@ -68,7 +107,7 @@ public class QuestionListController {
     /**
      * 답변을 기다리는 최신 4개 질문
      */
-    @GetMapping(path = "/unanswered-latest-4-questions")
+    @GetMapping(path = "/{c_id}/unanswered-latest-4-questions")
     public ResponseEntity<?> unansweredLatest4Questions(
             @PathVariable("c_id") Long cId
     ) {

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -399,7 +399,7 @@
   <nav>
     <a th:href="@{/}">Home</a>
     <a th:href="@{/communities/main}">Community</a>
-    <a href="#">일반게시판</a>
+    <a th:href="@{/communities/info/1}">일반게시판</a>
     <a href="#">My Page</a>
     <a href="#">About Us</a>
   </nav>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -14,7 +14,7 @@
     .container {
       display: flex;
       justify-content: space-between;
-      max-width: 1200px;
+      width: 70%;
       margin: 0 auto;
       padding: 20px;
       gap: 20px;
@@ -28,11 +28,15 @@
     }
 
     .left-column {
-      width: 25%;
+      width: 40%;
+    }
+
+    .middle-column {
+      width: 40%;
     }
 
     .right-column {
-      width: 25%;
+      width: 20%;
     }
 
     h2 {
@@ -181,16 +185,22 @@
 <main>
   <div class="container">
     <div class="left-column">
-      <h2>인기 커뮤니티</h2>
-      <div id="popularCommunities">
-        <!-- 여기에 동적으로 커뮤니티 카드가 추가된다 -->
+      <div class="section-header">
+        <h2>전체 커뮤니티 최신 질문</h2>
+<!--        <button id="all-questions-more-btn" class="view-more-btn">더보기</button>-->
+      </div>
+      <div id="left-card">
+        <!-- 여기에 동적으로 전체 게시판 최신 질문이 추가됨 -->
       </div>
     </div>
 
     <div class="middle-column">
-      <h2>인기 질문</h2>
-      <div id="popularQuestions">
-        <!-- 여기에 동적으로 질문 카드가 추가된다 -->
+      <div class="section-header">
+        <h2>일반 커뮤니티 최신 질문</h2>
+<!--        <button id="general-questions-more-btn" class="view-more-btn">더보기</button>-->
+      </div>
+      <div id="right-card">
+        <!-- 여기에 동적으로 일반 게시판 최신 질문이 추가됨 -->
       </div>
     </div>
 
@@ -199,28 +209,28 @@
         <div class="notice">
           <h3>공지사항</h3>
           <div id="notice">
-            <!-- 여기에 동적으로 공지사항 카드가 추가된다 -->
+            <!-- 여기에 동적으로 공지사항 카드가 추가됨 -->
           </div>
         </div>
 
         <div class="popular">
           <h3>인기 태그</h3>
           <div id="popularTags">
-            <!-- 여기에 동적으로 태그 카드가 추가된다 -->
+            <!-- 여기에 동적으로 태그 카드가 추가됨 -->
           </div>
         </div>
 
         <div class="popular">
           <h3>전 날 최다 조회 질문</h3>
           <div id="mostViewedQuestion">
-            <!-- 여기에 동적으로 질문 카드가 추가된다 -->
+            <!-- 여기에 동적으로 질문 카드가 추가됨 -->
           </div>
         </div>
 
         <div class="popular">
           <h3>전 날 최다 추천 답변</h3>
           <div id="mostLikedAnswer">
-            <!-- 여기에 동적으로 답변 카드가 추가된다 -->
+            <!-- 여기에 동적으로 답변 카드가 추가됨 -->
           </div>
         </div>
       </div>
@@ -238,9 +248,10 @@
 <script type="module">
 
   import CONFIG from '/static/js/config.js';
-  document.addEventListener('DOMContentLoaded', function () {
-    fetchPopularCommunities();
-    fetchPopularQuestions();
+
+  document.addEventListener('DOMContentLoaded', function() {
+    fetchLatestQuestions();
+    fetchLatestGeneralQuestions();
     fetchNotice();
     fetchPopularTags();
     fetchPopularQuestion();
@@ -250,13 +261,13 @@
   // const url = `http://localhost:8080/api/main`;
   // const baseURL = `http://localhost:8080`;
   // const token = 'eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuydtOyaqeyekEEiLCJ1aWQiOjJ9.oZzB9H5K81iaQ1qfeA95MfQLMGEpzqxKqWks21qcOR0';
-  const url = CONFIG.API.BASE_URL + CONFIG.API.ENDPOINTS.MAIN;
+  const url = CONFIG.API.BASE_URL + CONFIG.API.ENDPOINTS.COMMUNITIES;
   const baseURL = CONFIG.API.BASE_URL;
   const token = CONFIG.AUTH.DEFAULT_TOKEN;
 
-  /* 커뮤니티 */
-  function fetchPopularCommunities() {
-    fetch(url + `/premonth-topN-communities`, {
+  // 전체 게시판 최신 질문
+  function fetchLatestQuestions() {
+    fetch(url + `/N-latest-questions`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
@@ -264,10 +275,9 @@
     })
     .then(response => response.json())
     .then(data => {
-      console.log('Received data:', JSON.stringify(data, null, 2)); // 데이터 구조를 자세히 로그에 출력
-
-      if (data.data && Array.isArray(data.data)) {  // 데이터 구조를 확인하여 data.data 가 존재하고 배열인지 확인
-        displayPopularCommunities(data.data);
+      console.log('전체 게시판 Received data:', JSON.stringify(data, null, 2)); // 데이터 구조를 자세히 로그에 출력
+      if (data.data && Array.isArray(data.data)) {
+        displayQuestions(data.data, 'left-card');
       } else {
         console.error('Unexpected data structure:', data);
       }
@@ -275,34 +285,9 @@
     .catch(error => console.error('Error:', error));
   }
 
-  // 각 커뮤니티에 대한 카드를 생성
-  function displayPopularCommunities(communities) {
-    const container = document.getElementById('popularCommunities');
-    container.innerHTML = ''; // Clear existing content
-
-    communities.forEach((community, index) => {
-      const card = document.createElement('div');
-      card.className = 'community-card';
-      card.innerHTML = `
-       <span class="star">★</span>
-       <div class="community-info">
-           <p>${community.name}</p>
-           <p>회원수: ${community.memberCnt}</p>
-           <p>방문자수: ${community.visitorCnt}</p>
-       </div>
-      `;
-
-      // 커뮤니티 내부로 이동
-      card.addEventListener('click', () => {
-        window.location.href = `/communities/info/${community.id}`;
-      });
-      container.appendChild(card);
-    });
-  }
-
-  /* 질문 */
-  function fetchPopularQuestions() {
-    fetch(url + `/premonth-top5-questions`, {
+  // 일반 게시판 최신 질문
+  function fetchLatestGeneralQuestions() {
+    fetch(url + `/N-latest-questions-from-general`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
@@ -310,10 +295,8 @@
     })
     .then(response => response.json())
     .then(data => {
-      console.log('Received question data:', JSON.stringify(data, null, 2)); // 데이터 구조를 자세히 로그에 출력
-
-      if (data.data && Array.isArray(data.data)) {  // 데이터 구조를 확인하여 data.data 가 존재하고 배열인지 확인
-        displayPopularQuestions(data.data);
+      if (data.data && Array.isArray(data.data)) {
+        displayQuestions(data.data, 'right-card');
       } else {
         console.error('Unexpected data structure:', data);
       }
@@ -321,25 +304,23 @@
     .catch(error => console.error('Error:', error));
   }
 
-  // 각 질문에 대한 카드를 생성
-  function displayPopularQuestions(questions) {
-    const container = document.getElementById('popularQuestions');
+  // 질문 표시 함수
+  function displayQuestions(questions, id) {
+    const container = document.getElementById(id);
     container.innerHTML = '';
 
     questions.forEach((question, index) => {
       const card = document.createElement('div');
       card.className = 'question-item';
       card.innerHTML = `
-       <span class="index">${index + 1}</span>
-       <div class="community-info">
-           <p>${truncateText(question.title, 20)}</p>
-           <p></p>${truncateText(question.content, 50)}</p>
-           <p>조회수: ${question.viewCnt}</p>
-       </div>
-      `;
+            <span class="index">${index + 1}</span>
+            <div class="community-info">
+                <p>${truncateText(question.title, 20)}</p>
+                <p>${truncateText(question.content, 50)}</p>
+            </div>
+        `;
 
       displayQuestion(card, question.id);
-
       container.appendChild(card);
     });
   }
@@ -491,14 +472,6 @@
     console.log("questionId for answer: ", answer.questionId);
     displayQuestion(container, answer.questionId)
   }
-
-
-  // function displayQuestionCreation(container) {
-  //   // 질문 생성 페이지로 이동
-  //   container.addEventListener('click', () => {
-  //     window.location.href = `/questions/create`;
-  //   });
-  // }
 
   function displayQuestion(container, questionId) {
     // 질문 내부로 이동


### PR DESCRIPTION
## ✨ 작업 내용

- 일반 게시판에 커뮤니티 할당
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/5a49a515-03fc-45b0-975e-d4bfae18b69c">

- 메인 페이지에 전체 커뮤니티 / 일반 커뮤니티 분류로 최신 질문 목록 구현
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/1d60d7ef-52ab-48a5-816f-f6f16a5102be">

## 💬 리뷰 요구사항(선택)

- 일반 커뮤니티 할당의 경우 이후 배포에서 id 1번의 커뮤니티 데이터를 따로 생성해야 합니다.
- 예원 PR 병합 후 메인 페이지 CSS 확인 예정입니다.
- 마찬가지로 token 이름 수정 예정입니다.