### PR TITLE
fix: 인기 집계 스케줄링 주기 변경 및 404 해결

### DIFF
--- a/src/main/java/com/hanshin/supernova/popularity/presentation/MainPopularListController.java
+++ b/src/main/java/com/hanshin/supernova/popularity/presentation/MainPopularListController.java
@@ -52,9 +52,8 @@ public class MainPopularListController {
      */
     @GetMapping("/preday-most-viewed-question")
     public ResponseEntity<?> preDayMostViewedQuestion() {
-        return mainPopularListService.getMostViewedQuestion()
-                .map(ResponseDto::ok)
-                .orElseGet(ResponseDto::notFound);
+        var response = mainPopularListService.getMostViewedQuestion();
+        return ResponseDto.ok(response);
     }
 
     /**
@@ -62,9 +61,8 @@ public class MainPopularListController {
      */
     @GetMapping("/preday-most-recommended-answer")
     public ResponseEntity<?> preDayMostRecommendedAnswer() {
-        return mainPopularListService.getMostLikedAnswer()
-                .map(ResponseDto::ok)
-                .orElseGet(ResponseDto::notFound);
+        var response = mainPopularListService.getMostLikedAnswer();
+        return ResponseDto.ok(response);
     }
 
 }

--- a/src/main/java/com/hanshin/supernova/redis/community_stat/scheduler/VisitorScheduler.java
+++ b/src/main/java/com/hanshin/supernova/redis/community_stat/scheduler/VisitorScheduler.java
@@ -25,8 +25,7 @@ public class VisitorScheduler {
     private final RedisTemplate<String, String> redisTemplate;
     private final CommunityStatsRepository communityStatsRepository;
 
-//    @Scheduled(initialDelay = 3600000, fixedDelay = 3600000)
-    @Scheduled(initialDelay = 1000, fixedDelay = 300000)
+    @Scheduled(initialDelay = 300000, fixedDelay = 3600000)    // 5분 지연, 한 시간 주기
     public void updateVisitorData() {
         Set<String> keys = redisTemplate.keys("community:*:visit:*:*");
 

--- a/src/main/java/com/hanshin/supernova/redis/hashtag_stat/scheduler/TaggingScheduler.java
+++ b/src/main/java/com/hanshin/supernova/redis/hashtag_stat/scheduler/TaggingScheduler.java
@@ -23,13 +23,14 @@ public class TaggingScheduler {
     private final RedisTemplate<String, String> redisTemplate;
     private final HashtagStatsRepository hashtagStatsRepository;
 
-    @Scheduled(initialDelay = 86400000, fixedRate = 86400000)
-//    @Scheduled(initialDelay = 10000, fixedRate = 10000)
+    @Scheduled(initialDelay = 300000, fixedDelay = 3600000)    // 5분 지연, 한 시간 주기
     public void updateTaggingData() {
         Set<String> keys = redisTemplate.keys("hashtag:*:tagging:*:*");
 
         for (String key : keys) {
             try {
+                log.info("해시태그 key = {}", key);
+
                 String[] parts = key.split(":");
                 if (parts.length != 5) {
                     log.warn("Invalid key format: {}", key);

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -269,6 +269,7 @@
     // const baseURL = `http://localhost:8080`;
     // const token = 'eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuydtOyaqeyekEEiLCJ1aWQiOjJ9.oZzB9H5K81iaQ1qfeA95MfQLMGEpzqxKqWks21qcOR0';
     const url = CONFIG.API.BASE_URL + CONFIG.API.ENDPOINTS.COMMUNITIES;
+    const mainURL = CONFIG.API.BASE_URL + CONFIG.API.ENDPOINTS.MAIN;
     const baseURL = CONFIG.API.BASE_URL;
     const token = CONFIG.AUTH.DEFAULT_TOKEN;
 
@@ -372,7 +373,7 @@
 
     /* 해시태그 */
     function fetchPopularTags() {
-        fetch(url + `/preday-top10-hashtag`, {
+        fetch(mainURL + `/preday-top10-hashtag`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json'
@@ -384,6 +385,8 @@
 
                 if (data.data && Array.isArray(data.data)) {  // 데이터 구조를 확인하여 data.data 가 존재하고 배열인지 확인
                     displayPopularTags(data.data);
+                } else if(data.data == null) {
+                    displayNoDataById('popularTags');
                 } else {
                     console.error('Unexpected data structure:', data);
                 }
@@ -419,7 +422,7 @@
 
     /* 최다 조회 질문 */
     function fetchPopularQuestion() {
-        fetch(url + `/preday-most-viewed-question`, {
+        fetch(mainURL + `/preday-most-viewed-question`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json'
@@ -431,6 +434,8 @@
 
                 if (data.data) {  // 데이터 구조를 확인하여 data.data 가 존재하고 배열인지 확인
                     displayPopularQuestion(data.data);
+                } else if(data.data == null) {
+                    displayNoDataById('mostViewedQuestion');
                 } else {
                     console.error('Unexpected data structure:', data);
                 }
@@ -442,8 +447,7 @@
     function displayPopularQuestion(question) {
         const container = document.getElementById('mostViewedQuestion');
         container.innerHTML = `
-     <span>Q. ${question.id})</span>
-     <span>${truncateText(question.title, 40)}</span>
+     <span>Q. ${truncateText(question.title, 40)}</span>
     `;
 
         displayQuestion(container, question.id);
@@ -451,7 +455,7 @@
 
     /* 최다 추천 답변 */
     function fetchPopularAnswer() {
-        fetch(url + `/preday-most-recommended-answer`, {
+        fetch(mainURL + `/preday-most-recommended-answer`, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json'
@@ -459,10 +463,13 @@
         })
             .then(response => response.json())
             .then(data => {
-                console.log('Received viewed question data:', JSON.stringify(data, null, 2)); // 데이터 구조를 자세히 로그에 출력
+                console.log('최다 추천 답변 데이터:', JSON.stringify(data, null, 2)); // 데이터 구조를 자세히 로그에 출력
+                console.log('data.data = ', data.data);
 
                 if (data.data) {  // 데이터 구조를 확인하여 data.data 가 존재하고 배열인지 확인
                     displayPopularAnswer(data.data);
+                } else if(data.data == null) {
+                    displayNoDataById('mostLikedAnswer');
                 } else {
                     console.error('Unexpected data structure:', data);
                 }
@@ -470,12 +477,19 @@
             .catch(error => console.error('Error:', error));
     }
 
+    function displayNoDataById(id) {
+        const container = document.getElementById(id);
+        container.innerHTML = `
+            <p>(데이터가 존재하지 않습니다. 활동을 시작해주세요!)</p>
+          `;
+    }
+
     // 답변 대한 카드를 생성
     function displayPopularAnswer(answer) {
         const container = document.getElementById('mostLikedAnswer');
-        container.innerHTML = `
-      <p>${truncateText(answer.answer, 50)}</p>
-    `;
+            container.innerHTML = `
+            <p>A. ${truncateText(answer.answer, 50)}</p>
+          `;
         console.log("questionId for answer: ", answer.questionId);
         displayQuestion(container, answer.questionId)
     }


### PR DESCRIPTION
## ✨ 작업 내용

- 인기 태그와 인기 커뮤니티를 집계하는 스케줄링 작업을 초기 5분 지연 및 1시간 주기로 변경하였습니다.
- 기존 404 에러에 대해 null data 를 처리하는 메서드인 `displayNoDataById()`를 추가하였습니다. 콘솔 예외처리 대신 '(데이터가 존재하지 않습니다. 활동을 시작해주세요!)' 라는 문구가 뜹니다.
- 기존에 잘못 매칭되어 있던 url 대신 main 앤드포인트가 있는 mainURL 로 수정하였습니다.