### PR TITLE
fix: 커뮤니티 목록 나타나지 않는 오류 해결

### DIFF
--- a/src/main/resources/templates/community/community_list.html
+++ b/src/main/resources/templates/community/community_list.html
@@ -107,6 +107,7 @@
 </head>
 <body>
 <header th:replace="~{header :: header}"></header>
+<div th:insert="~{header :: headerScripts}"></div>
 
 <div class="container">
   <div class="page-header">


### PR DESCRIPTION
## ✨ 작업 내용

- 헤더 관련 스크립트 태그가 빠져서 fetchWithAuth 메서드가 작동되지 않으며 목록이 나타나지 않았던 문제를 해결했습니다.