### PR TITLE
error: 로그인 타임아웃 해결

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -107,5 +107,5 @@ jobs:
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ env.SERVICE_NAME }}:${{env.IMAGE_TAG}}
             if [ $(sudo docker ps -q) ]; then sudo docker stop $(sudo docker ps -q); fi
             if [ $(sudo docker ps -aq) ]; then sudo docker rm $(sudo docker ps -aq); fi
-            sudo docker run -d -p 8080:8080 --name ${{ env.SERVICE_NAME }}-${{env.IMAGE_TAG}} ${{ secrets.DOCKER_USERNAME }}/${{ env.SERVICE_NAME }}:${{env.IMAGE_TAG}}
+            sudo docker run -d -p 8080:8080 -e SPRING_PROFILES_ACTIVE=prod --name ${{ env.SERVICE_NAME }}-${{env.IMAGE_TAG}} ${{ secrets.DOCKER_USERNAME }}/${{ env.SERVICE_NAME }}:${{env.IMAGE_TAG}}
             sudo docker image prune -f

--- a/src/main/java/com/hanshin/supernova/security/application/JwtService.java
+++ b/src/main/java/com/hanshin/supernova/security/application/JwtService.java
@@ -38,17 +38,17 @@ public class JwtService {
     private int refreshTokenExpiration;
 
     @Getter
-    private int accessTokenExpirationMinutes;
+    private Long accessTokenExpirationInMillis;
 
     @Getter
-    private int refreshTokenExpirationMinutes;
+    private Long refreshTokenExpirationInMillis;
 
 
     @PostConstruct
     public void init() {
-        // 초를 분으로 변환
-        this.accessTokenExpirationMinutes = this.accessTokenExpiration / 60;
-        this.refreshTokenExpirationMinutes = this.refreshTokenExpiration / 60;
+        // 초를 밀리초로 변환
+        this.accessTokenExpirationInMillis = this.accessTokenExpiration * 1000L;
+        this.refreshTokenExpirationInMillis = this.refreshTokenExpiration * 1000L;
     }
 
     private SecretKey key;
@@ -111,7 +111,7 @@ public class JwtService {
                 .claim("role", role)
                 .claim("userId", userId)
                 .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + accessTokenExpirationMinutes * 1000L))
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpirationInMillis))
                 .signWith(key)
                 .compact();
     }
@@ -123,7 +123,7 @@ public class JwtService {
                 .claim("role", role)
                 .claim("userId", userId)
                 .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpirationMinutes * 1000L))
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpirationInMillis))
                 .signWith(key)
                 .compact();
     }


### PR DESCRIPTION
## ✨ 작업 내용

- 초로 설정된 타임아웃에 밀리초 연산(1000L 곱하기)을 해야 하는데, 처음 분 단위로 바꾸느라 60으로 나눈 게 원인이었음.
- 따라서 3600 / 60 = 60 에 1000L 을 곱한, 밀리세컨드 단위의 60초(1분)이 타임아웃 시간으로 된 것.
- 이를 정상적으로 고치고 비정상 로그인 타임아웃을 해결