### PR TITLE
feat: 도메인 추가하면서 외부 80포트를 포워딩

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -107,5 +107,5 @@ jobs:
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ env.SERVICE_NAME }}:${{env.IMAGE_TAG}}
             if [ $(sudo docker ps -q) ]; then sudo docker stop $(sudo docker ps -q); fi
             if [ $(sudo docker ps -aq) ]; then sudo docker rm $(sudo docker ps -aq); fi
-            sudo docker run -d -p 8080:8080 -e SPRING_PROFILES_ACTIVE=prod --name ${{ env.SERVICE_NAME }}-${{env.IMAGE_TAG}} ${{ secrets.DOCKER_USERNAME }}/${{ env.SERVICE_NAME }}:${{env.IMAGE_TAG}}
+            sudo docker run -d -p 80:8080 -e SPRING_PROFILES_ACTIVE=prod --name ${{ env.SERVICE_NAME }}-${{env.IMAGE_TAG}} ${{ secrets.DOCKER_USERNAME }}/${{ env.SERVICE_NAME }}:${{env.IMAGE_TAG}}
             sudo docker image prune -f


### PR DESCRIPTION
## ✨ 작업 내용

- 기존 Docker 실행 옵션을 보면 -p 8080:8080로 되어 있어, 호스트(EC2)의 8080 포트를 컨테이너 내부 8080 포트와 연결하고 있음
- 도메인 연결 후 8080을 붙이지 않기 위해 80 호스트를 컨테이터 8080으로 포워딩 진행